### PR TITLE
Enable dependabot for @seamapi/types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: feat
+      include: scope
+    allow:
+      - dependency-name: '@seamapi/types'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    groups:
+      seam:
+        dependency-type: development
+        patterns:
+          - '@seamapi/types'
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
Enables dependabot to open PRs when new types are published.

- Does not include blueprint yet (will include that after version 1).
- Does not include auto-merge or auto-close yet as we have on some of the SDKs.