### PR TITLE
Add path metadata

### DIFF
--- a/src/data/paths.yaml
+++ b/src/data/paths.yaml
@@ -1,0 +1,3 @@
+---
+/acs/systems:
+  description: null

--- a/src/lib/blueprint.ts
+++ b/src/lib/blueprint.ts
@@ -13,11 +13,14 @@ export const blueprint = async (
   const codeSampleDefinitions =
     'codeSampleDefinitions' in metadata ? metadata.codeSampleDefinitions : []
 
+  // UPSTREAM: Ideally, path metadata would be unnecessary and contained inside the blueprint.
+  const pathMetadata = 'pathMetadata' in metadata ? metadata.pathMetadata : {}
+
   const typesModule = TypesModuleSchema.parse({
     ...types,
     codeSampleDefinitions,
   })
 
   const blueprint = await createBlueprint(typesModule, { formatCode })
-  Object.assign(metadata, blueprint)
+  Object.assign(metadata, { ...blueprint, pathMetadata })
 }

--- a/src/lib/layout-context.ts
+++ b/src/lib/layout-context.ts
@@ -7,6 +7,8 @@ import type {
 } from '@seamapi/blueprint'
 import { pascalCase } from 'change-case'
 
+import type { PathMetadata } from './reference.js'
+
 const supportedSdks: CodeSampleSdk[] = [
   'javascript',
   'python',
@@ -113,6 +115,7 @@ interface ContextResource {
 type ContextEndpoint = Pick<Endpoint, 'path' | 'description'>
 
 export interface RouteLayoutContext {
+  description: string | null
   resources: ContextResource[]
   endpoints: ContextEndpoint[]
 }
@@ -121,7 +124,9 @@ export function setApiRouteLayoutContext(
   file: Partial<RouteLayoutContext>,
   route: Route,
   blueprint: Blueprint,
+  pathMetadata: PathMetadata,
 ): void {
+  file.description = pathMetadata[route.path]?.description ?? null
   file.endpoints = route.endpoints.map(({ path, name, description }) => ({
     path,
     name,

--- a/src/metalsmith.ts
+++ b/src/metalsmith.ts
@@ -25,6 +25,7 @@ Metalsmith(rootDir)
   .use(
     metadata({
       codeSampleDefinitions: './data/code-sample-definitions',
+      pathMetadata: './data/paths.yaml',
     }),
   )
   .use(blueprint)


### PR DESCRIPTION
This adds a new file `src/data/paths.yaml` for injecting content or information that is not supported by blueprint. Ideally, we do not need this file, however adding some features to blueprint may be more complicated, or out of scope beyond the docs. We can use this file to move faster to meet documentation requirements in those cases.

If we decide some content will never move upstream, we can move it out of `src/data/paths.yaml` into something more specific to the docs, similar to how code-samples work.

This PR introduces three new properties:

1. `description` for routes (and eventually namespaces).
2. `events` (unused but needed soon)
3. `resources` to add additional resources that should be documented under a route but may not be returned by an endpoint under that route. I'm not sure if we need this one yet, but this is really a starting point to experiment with how to document relevant properties and resources in other contexts, e.g., should EVERY device property be documented under `/devices` AND `/thermostats`? Or should some properties by included / excluded on those routes. 