### PR TITLE
Remove parentheses around type for sub-properties

### DIFF
--- a/docs/api/acs/systems/README.md
+++ b/docs/api/acs/systems/README.md
@@ -153,13 +153,13 @@ Format: `String`
 Format: `Object`
 
 <details>
-<summary>lan_address (<code>string</code>)</summary>
+<summary>lan_address <code>string</code></summary>
 </details>
 <details>
-<summary>mobile_access_uuid (<code>string</code>)</summary>
+<summary>mobile_access_uuid <code>string</code></summary>
 </details>
 <details>
-<summary>system_id (<code>string</code>)</summary>
+<summary>system_id <code>string</code></summary>
 </details>
 ---
 

--- a/src/layouts/api-route.hbs
+++ b/src/layouts/api-route.hbs
@@ -32,7 +32,7 @@ Possible enum values:
 {{#if objectProperties}}
 {{#each objectProperties}}
 <details>
-<summary>{{this.name}} (<code>{{this.format}}</code>)</summary>
+<summary>{{this.name}} <code>{{this.format}}</code></summary>
 {{#if this.description}}
 {{this.description}}
 {{/if}}


### PR DESCRIPTION
This looks a lot cleaner
![image](https://github.com/user-attachments/assets/651bf597-6cdd-4483-a4bd-ab6638e0ff71)
