### PR TITLE
Update README optional requirements and devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 RUN apt-get update
 
 RUN apt-get install -y php ruby ruby-dev golang-go
-RUN gem install standard -v 1.31.0
+RUN gem install syntax_tree -v 6.2.0
 
 RUN wget https://github.com/mvdan/sh/releases/download/v3.9.0/shfmt_v3.9.0_linux_amd64 -O shfmt \
  && chmod a+x shfmt \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ GitHub actions will automatically ensure the formatting is applied for all pull 
 - [shfmt](https://github.com/mvdan/sh)
 - [ruff](https://github.com/astral-sh/ruff)
 - [gofmt](https://go.dev/blog/gofmt)
-- [standardrb](https://github.com/standardrb/standard)
+- [syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree)
 
 ## GitHub Actions
 


### PR DESCRIPTION
This PR updates README and devcontainer config to replace `standard` Ruby formatter with `syntax_tree` that is required by Ruby plugin for prettier. 

Marking the PR as draft while waiting for a response to https://github.com/seamapi/docs/pull/452#issuecomment-2539053999