### PR TITLE
Compare GitBook and GitHub MD 2

### DIFF
--- a/docs/api-clients/noise_sensors/README.md
+++ b/docs/api-clients/noise_sensors/README.md
@@ -138,6 +138,14 @@ ID (`uuid`) of the [noise threshold](../../products/noise-sensors/#what-is-a-thr
 
 </details>
 
+<details>
+
+<summary><code>noise_threshold_name</code> <code>string</code></summary>
+
+Name of the [noise threshold](../../products/noise-sensors/#what-is-a-threshold) that was triggered, for example, `builtin_first_disturbance`.
+
+</details>
+
 ## Next Steps
 
 For more details on each endpoint, see our API references:

--- a/docs/api/user_identities/update-a-user-identity.md
+++ b/docs/api/user_identities/update-a-user-identity.md
@@ -1,2 +1,0 @@
-# Update a User Identity
-


### PR DESCRIPTION
First `details` block in "Events" was added through GitBook. Second `details` block was added through GitHub using exact code deleted in previous PR and originally added through GitBook.