### PR TITLE
Format child prop names as code and fix details line spacing

### DIFF
--- a/docs/api/acs/credentials/README.md
+++ b/docs/api/acs/credentials/README.md
@@ -212,28 +212,28 @@ Format: `Object`
 Visionline-specific metadata for the credential.
 
 <details>
-<summary>auto_join <code>boolean</code></summary>
+<summary><code>auto_join</code> <code>boolean</code></summary>
 </details>
 <details>
-<summary>card_function_type <code>enum</code></summary>
+<summary><code>card_function_type</code> <code>enum</code></summary>
 </details>
 <details>
-<summary>card_id <code>string</code></summary>
+<summary><code>card_id</code> <code>string</code></summary>
 </details>
 <details>
-<summary>common_acs_entrance_ids <code>list</code></summary>
+<summary><code>common_acs_entrance_ids</code> <code>list</code></summary>
 </details>
 <details>
-<summary>credential_id <code>string</code></summary>
+<summary><code>credential_id</code> <code>string</code></summary>
 </details>
 <details>
-<summary>guest_acs_entrance_ids <code>list</code></summary>
+<summary><code>guest_acs_entrance_ids</code> <code>list</code></summary>
 </details>
 <details>
-<summary>is_valid <code>boolean</code></summary>
+<summary><code>is_valid</code> <code>boolean</code></summary>
 </details>
 <details>
-<summary>joiner_acs_credential_ids <code>list</code></summary>
+<summary><code>joiner_acs_credential_ids</code> <code>list</code></summary>
 </details>
 
 ---

--- a/docs/api/acs/credentials/README.md
+++ b/docs/api/acs/credentials/README.md
@@ -212,29 +212,61 @@ Format: `Object`
 Visionline-specific metadata for the credential.
 
 <details>
-<summary><code>auto_join</code> <code>boolean</code></summary>
+
+<summary><code>auto_join</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>card_function_type</code> <code>enum</code></summary>
+
+<summary><code>card_function_type</code> Format: <code>enum</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>card_id</code> <code>string</code></summary>
+
+<summary><code>card_id</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>common_acs_entrance_ids</code> <code>list</code></summary>
+
+<summary><code>common_acs_entrance_ids</code> Format: <code>list</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>credential_id</code> <code>string</code></summary>
+
+<summary><code>credential_id</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>guest_acs_entrance_ids</code> <code>list</code></summary>
+
+<summary><code>guest_acs_entrance_ids</code> Format: <code>list</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>is_valid</code> <code>boolean</code></summary>
+
+<summary><code>is_valid</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>joiner_acs_credential_ids</code> <code>list</code></summary>
+
+<summary><code>joiner_acs_credential_ids</code> Format: <code>list</code></summary>
+
+
 </details>
+
 
 ---
 

--- a/docs/api/acs/entrances/README.md
+++ b/docs/api/acs/entrances/README.md
@@ -27,20 +27,40 @@ ID of the access control system that contains the entrance.
 Format: `Object`
 
 <details>
-<summary><code>door_name</code> <code>string</code></summary>
+
+<summary><code>door_name</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_number</code> <code>number</code></summary>
+
+<summary><code>door_number</code> Format: <code>number</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_type</code> <code>enum</code></summary>
+
+<summary><code>door_type</code> Format: <code>enum</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>pms_id</code> <code>string</code></summary>
+
+<summary><code>pms_id</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>stand_open</code> <code>boolean</code></summary>
+
+<summary><code>stand_open</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 
 ---
 
@@ -67,14 +87,26 @@ Display name for the entrance.
 Format: `Object`
 
 <details>
-<summary><code>access_point_name</code> <code>string</code></summary>
+
+<summary><code>access_point_name</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>common_area_number</code> <code>number</code></summary>
+
+<summary><code>common_area_number</code> Format: <code>number</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>inner_access_points_names</code> <code>list</code></summary>
+
+<summary><code>inner_access_points_names</code> Format: <code>list</code></summary>
+
+
 </details>
+
 
 ---
 
@@ -90,17 +122,33 @@ Format: `List`
 Format: `Object`
 
 <details>
-<summary><code>accessibility_type</code> <code>string</code></summary>
+
+<summary><code>accessibility_type</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_name</code> <code>string</code></summary>
+
+<summary><code>door_name</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_type</code> <code>string</code></summary>
+
+<summary><code>door_type</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>is_connected</code> <code>boolean</code></summary>
+
+<summary><code>is_connected</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 
 ---
 
@@ -109,29 +157,61 @@ Format: `Object`
 Format: `Object`
 
 <details>
-<summary><code>battery_level</code> <code>string</code></summary>
+
+<summary><code>battery_level</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_name</code> <code>string</code></summary>
+
+<summary><code>door_name</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>intrusion_alarm</code> <code>boolean</code></summary>
+
+<summary><code>intrusion_alarm</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>left_open_alarm</code> <code>boolean</code></summary>
+
+<summary><code>left_open_alarm</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>lock_type</code> <code>string</code></summary>
+
+<summary><code>lock_type</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>locked_state</code> <code>string</code></summary>
+
+<summary><code>locked_state</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>online</code> <code>boolean</code></summary>
+
+<summary><code>online</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>privacy_mode</code> <code>boolean</code></summary>
+
+<summary><code>privacy_mode</code> Format: <code>boolean</code></summary>
+
+
 </details>
+
 
 ---
 
@@ -140,14 +220,26 @@ Format: `Object`
 Format: `Object`
 
 <details>
-<summary><code>door_description</code> <code>string</code></summary>
+
+<summary><code>door_description</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_name</code> <code>string</code></summary>
+
+<summary><code>door_name</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>ext_door_id</code> <code>string</code></summary>
+
+<summary><code>ext_door_id</code> Format: <code>string</code></summary>
+
+
 </details>
+
 
 ---
 
@@ -156,14 +248,26 @@ Format: `Object`
 Format: `Object`
 
 <details>
-<summary><code>door_category</code> <code>enum</code></summary>
+
+<summary><code>door_category</code> Format: <code>enum</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>door_name</code> <code>string</code></summary>
+
+<summary><code>door_name</code> Format: <code>string</code></summary>
+
+
 </details>
+
 <details>
-<summary><code>profiles</code> <code>list</code></summary>
+
+<summary><code>profiles</code> Format: <code>list</code></summary>
+
+
 </details>
+
 
 ---
 

--- a/docs/api/acs/entrances/README.md
+++ b/docs/api/acs/entrances/README.md
@@ -27,19 +27,19 @@ ID of the access control system that contains the entrance.
 Format: `Object`
 
 <details>
-<summary>door_name <code>string</code></summary>
+<summary><code>door_name</code> <code>string</code></summary>
 </details>
 <details>
-<summary>door_number <code>number</code></summary>
+<summary><code>door_number</code> <code>number</code></summary>
 </details>
 <details>
-<summary>door_type <code>enum</code></summary>
+<summary><code>door_type</code> <code>enum</code></summary>
 </details>
 <details>
-<summary>pms_id <code>string</code></summary>
+<summary><code>pms_id</code> <code>string</code></summary>
 </details>
 <details>
-<summary>stand_open <code>boolean</code></summary>
+<summary><code>stand_open</code> <code>boolean</code></summary>
 </details>
 
 ---
@@ -67,13 +67,13 @@ Display name for the entrance.
 Format: `Object`
 
 <details>
-<summary>access_point_name <code>string</code></summary>
+<summary><code>access_point_name</code> <code>string</code></summary>
 </details>
 <details>
-<summary>common_area_number <code>number</code></summary>
+<summary><code>common_area_number</code> <code>number</code></summary>
 </details>
 <details>
-<summary>inner_access_points_names <code>list</code></summary>
+<summary><code>inner_access_points_names</code> <code>list</code></summary>
 </details>
 
 ---
@@ -90,16 +90,16 @@ Format: `List`
 Format: `Object`
 
 <details>
-<summary>accessibility_type <code>string</code></summary>
+<summary><code>accessibility_type</code> <code>string</code></summary>
 </details>
 <details>
-<summary>door_name <code>string</code></summary>
+<summary><code>door_name</code> <code>string</code></summary>
 </details>
 <details>
-<summary>door_type <code>string</code></summary>
+<summary><code>door_type</code> <code>string</code></summary>
 </details>
 <details>
-<summary>is_connected <code>boolean</code></summary>
+<summary><code>is_connected</code> <code>boolean</code></summary>
 </details>
 
 ---
@@ -109,28 +109,28 @@ Format: `Object`
 Format: `Object`
 
 <details>
-<summary>battery_level <code>string</code></summary>
+<summary><code>battery_level</code> <code>string</code></summary>
 </details>
 <details>
-<summary>door_name <code>string</code></summary>
+<summary><code>door_name</code> <code>string</code></summary>
 </details>
 <details>
-<summary>intrusion_alarm <code>boolean</code></summary>
+<summary><code>intrusion_alarm</code> <code>boolean</code></summary>
 </details>
 <details>
-<summary>left_open_alarm <code>boolean</code></summary>
+<summary><code>left_open_alarm</code> <code>boolean</code></summary>
 </details>
 <details>
-<summary>lock_type <code>string</code></summary>
+<summary><code>lock_type</code> <code>string</code></summary>
 </details>
 <details>
-<summary>locked_state <code>string</code></summary>
+<summary><code>locked_state</code> <code>string</code></summary>
 </details>
 <details>
-<summary>online <code>boolean</code></summary>
+<summary><code>online</code> <code>boolean</code></summary>
 </details>
 <details>
-<summary>privacy_mode <code>boolean</code></summary>
+<summary><code>privacy_mode</code> <code>boolean</code></summary>
 </details>
 
 ---
@@ -140,13 +140,13 @@ Format: `Object`
 Format: `Object`
 
 <details>
-<summary>door_description <code>string</code></summary>
+<summary><code>door_description</code> <code>string</code></summary>
 </details>
 <details>
-<summary>door_name <code>string</code></summary>
+<summary><code>door_name</code> <code>string</code></summary>
 </details>
 <details>
-<summary>ext_door_id <code>string</code></summary>
+<summary><code>ext_door_id</code> <code>string</code></summary>
 </details>
 
 ---
@@ -156,13 +156,13 @@ Format: `Object`
 Format: `Object`
 
 <details>
-<summary>door_category <code>enum</code></summary>
+<summary><code>door_category</code> <code>enum</code></summary>
 </details>
 <details>
-<summary>door_name <code>string</code></summary>
+<summary><code>door_name</code> <code>string</code></summary>
 </details>
 <details>
-<summary>profiles <code>list</code></summary>
+<summary><code>profiles</code> <code>list</code></summary>
 </details>
 
 ---

--- a/docs/api/acs/systems/README.md
+++ b/docs/api/acs/systems/README.md
@@ -162,7 +162,7 @@ Indicates if the `acs_system` is a credential manager.
 Format: `Object`
 
 <details>
-<summary>time_zone <code>string</code></summary>
+<summary><code>time_zone</code> <code>string</code></summary>
 Time zone in which the `acs_system` is located.
 </details>
 
@@ -219,15 +219,15 @@ Format: `String`
 Format: `Object`
 
 <details>
-<summary>lan_address <code>string</code></summary>
+<summary><code>lan_address</code> <code>string</code></summary>
 IP address or hostname of the main Visionline server relative to the Seam Bridge on the local network.
 </details>
 <details>
-<summary>mobile_access_uuid <code>string</code></summary>
+<summary><code>mobile_access_uuid</code> <code>string</code></summary>
 Keyset loaded into a reader. Mobile keys and reader administration tools securely authenticate only with readers programmed with a matching keyset.
 </details>
 <details>
-<summary>system_id <code>string</code></summary>
+<summary><code>system_id</code> <code>string</code></summary>
 Unique ID assigned by the ASSA ABLOY licensing team that identifies each hotel in your credential manager.
 </details>
 

--- a/docs/api/acs/systems/README.md
+++ b/docs/api/acs/systems/README.md
@@ -162,9 +162,13 @@ Indicates if the `acs_system` is a credential manager.
 Format: `Object`
 
 <details>
-<summary><code>time_zone</code> <code>string</code></summary>
+
+<summary><code>time_zone</code> Format: <code>string</code></summary>
+
 Time zone in which the `acs_system` is located.
+
 </details>
+
 
 ---
 
@@ -219,17 +223,29 @@ Format: `String`
 Format: `Object`
 
 <details>
-<summary><code>lan_address</code> <code>string</code></summary>
+
+<summary><code>lan_address</code> Format: <code>string</code></summary>
+
 IP address or hostname of the main Visionline server relative to the Seam Bridge on the local network.
+
 </details>
+
 <details>
-<summary><code>mobile_access_uuid</code> <code>string</code></summary>
+
+<summary><code>mobile_access_uuid</code> Format: <code>string</code></summary>
+
 Keyset loaded into a reader. Mobile keys and reader administration tools securely authenticate only with readers programmed with a matching keyset.
+
 </details>
+
 <details>
-<summary><code>system_id</code> <code>string</code></summary>
+
+<summary><code>system_id</code> Format: <code>string</code></summary>
+
 Unique ID assigned by the ASSA ABLOY licensing team that identifies each hotel in your credential manager.
+
 </details>
+
 
 ---
 

--- a/docs/api/acs/users/README.md
+++ b/docs/api/acs/users/README.md
@@ -11,11 +11,11 @@ Format: `Object`
 `starts_at` and `ends_at` timestamps for the `acs_user`'s access.
 
 <details>
-<summary>ends_at <code>datetime</code></summary>
+<summary><code>ends_at</code> <code>datetime</code></summary>
 Date and time at which the user's access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
 </details>
 <details>
-<summary>starts_at <code>datetime</code></summary>
+<summary><code>starts_at</code> <code>datetime</code></summary>
 Date and time at which the user's access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
 </details>
 

--- a/docs/api/acs/users/README.md
+++ b/docs/api/acs/users/README.md
@@ -11,13 +11,21 @@ Format: `Object`
 `starts_at` and `ends_at` timestamps for the `acs_user`'s access.
 
 <details>
-<summary><code>ends_at</code> <code>datetime</code></summary>
+
+<summary><code>ends_at</code> Format: <code>datetime</code></summary>
+
 Date and time at which the user's access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
 </details>
+
 <details>
-<summary><code>starts_at</code> <code>datetime</code></summary>
+
+<summary><code>starts_at</code> Format: <code>datetime</code></summary>
+
 Date and time at which the user's access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
 </details>
+
 
 ---
 

--- a/src/layouts/api-route.hbs
+++ b/src/layouts/api-route.hbs
@@ -32,7 +32,7 @@ Possible enum values:
 {{#if objectProperties}}
 {{#each objectProperties}}
 <details>
-<summary>{{this.name}} <code>{{this.format}}</code></summary>
+<summary><code>{{this.name}}</code> <code>{{this.format}}</code></summary>
 {{#if this.description}}
 {{this.description}}
 {{/if}}

--- a/src/layouts/api-route.hbs
+++ b/src/layouts/api-route.hbs
@@ -32,7 +32,7 @@ Possible enum values:
 {{#if objectProperties}}
 {{#each objectProperties}}
 <details>
-<summary><code>{{this.name}}</code> <code>{{this.format}}</code></summary>
+<summary><code>{{this.name}}</code> Format: <code>{{this.format}}</code></summary>
 {{#if this.description}}
 {{this.description}}
 {{/if}}

--- a/src/layouts/api-route.hbs
+++ b/src/layouts/api-route.hbs
@@ -32,11 +32,15 @@ Possible enum values:
 {{#if objectProperties}}
 {{#each objectProperties}}
 <details>
+
 <summary><code>{{this.name}}</code> Format: <code>{{this.format}}</code></summary>
+
 {{#if this.description}}
 {{this.description}}
 {{/if}}
+
 </details>
+
 {{/each}}
 {{/if}}
 


### PR DESCRIPTION
@andrii-balitskyi and @razor-x Could I please suggest that we format prop names within prop child objects as code? 

> I don't love that we end up with two separate bits, both formatted as code, right next to each other, so another option would be to add "Format: " before the second bit. I'll add a suggestion in a comment to see what you think.

 Committed it. Please let me know if you don't like the "Format: " thing.
Thanks!