### PR TITLE
feat: sort request.parameters by required first, then name alphabetically

### DIFF
--- a/docs/api/acs/credentials/list.md
+++ b/docs/api/acs/credentials/list.md
@@ -199,15 +199,6 @@ func main() {
 
 ## Request Parameters
 
-### `acs_user_id`
-
-Type: `string`
-Required: No
-
-ID of the ACS user for which you want to retrieve all credentials.
-
-***
-
 ### `acs_system_id`
 
 Type: `string`
@@ -217,12 +208,12 @@ ID of the access control system for which you want to retrieve all credentials.
 
 ***
 
-### `user_identity_id`
+### `acs_user_id`
 
 Type: `string`
 Required: No
 
-ID of the user identity for which you want to retrieve all credentials.
+ID of the ACS user for which you want to retrieve all credentials.
 
 ***
 
@@ -250,6 +241,15 @@ Type: `number`
 Required: No
 
 Number of credentials to return.
+
+***
+
+### `user_identity_id`
+
+Type: `string`
+Required: No
+
+ID of the user identity for which you want to retrieve all credentials.
 
 ***
 

--- a/docs/api/acs/encoders/list.md
+++ b/docs/api/acs/encoders/list.md
@@ -14,21 +14,21 @@ Returns a list of all [encoders](../../../capability-guides/access-systems/worki
 
 ## Request Parameters
 
+### `acs_encoder_ids`
+
+Type: `array`
+Required: No
+
+IDs of the `acs_encoder`s that you want to retrieve.
+
+***
+
 ### `acs_system_id`
 
 Type: `string`
 Required: No
 
 ID of the `acs_system` for which you want to retrieve all `acs_encoder`s.
-
-***
-
-### `limit`
-
-Type: `number`
-Required: No
-
-Number of `acs_encoders` to return.
 
 ***
 
@@ -41,12 +41,12 @@ IDs of the `acs_system`s for which you want to retrieve all `acs_encoder`s.
 
 ***
 
-### `acs_encoder_ids`
+### `limit`
 
-Type: `array`
+Type: `number`
 Required: No
 
-IDs of the `acs_encoder`s that you want to retrieve.
+Number of `acs_encoders` to return.
 
 ***
 

--- a/docs/api/acs/encoders/simulate/next_credential_encode_will_fail.md
+++ b/docs/api/acs/encoders/simulate/next_credential_encode_will_fail.md
@@ -23,21 +23,21 @@ ID of the `acs_encoder` that will be used in the next request to encode the `acs
 
 ***
 
-### `error_code`
-
-Type: `string`
-Required: No
-
-Code of the error to simulate.
-
-***
-
 ### `acs_credential_id`
 
 Type: `string`
 Required: No
 
 ID of the `acs_credential` that will fail to be encoded onto a card in the next request.
+
+***
+
+### `error_code`
+
+Type: `string`
+Required: No
+
+Code of the error to simulate.
 
 ***
 

--- a/docs/api/acs/encoders/simulate/next_credential_scan_will_fail.md
+++ b/docs/api/acs/encoders/simulate/next_credential_scan_will_fail.md
@@ -23,7 +23,7 @@ ID of the `acs_encoder` that will fail to scan the `acs_credential` in the next 
 
 ***
 
-### `error_code`
+### `acs_credential_id_on_seam`
 
 Type: `string`
 Required: No
@@ -32,7 +32,7 @@ Required: No
 
 ***
 
-### `acs_credential_id_on_seam`
+### `error_code`
 
 Type: `string`
 Required: No

--- a/docs/api/acs/encoders/simulate/next_credential_scan_will_succeed.md
+++ b/docs/api/acs/encoders/simulate/next_credential_scan_will_succeed.md
@@ -14,21 +14,21 @@ Simulates that the next attempt to scan a [credential](../../../../capability-gu
 
 ## Request Parameters
 
-### `acs_credential_id_on_seam`
-
-Type: `string`
-Required: No
-
-ID of the Seam `acs_credential` that matches the `acs_credential` on the encoder in this simulation.
-
-***
-
 ### `acs_encoder_id`
 
 Type: `string`
 Required: Yes
 
 ID of the `acs_encoder` that will be used in the next request to scan the `acs_credential`.
+
+***
+
+### `acs_credential_id_on_seam`
+
+Type: `string`
+Required: No
+
+ID of the Seam `acs_credential` that matches the `acs_credential` on the encoder in this simulation.
 
 ***
 

--- a/docs/api/acs/users/create.md
+++ b/docs/api/acs/users/create.md
@@ -188,6 +188,24 @@ api.AcsUser{AcsUserId: "123e4567-e89b-12d3-a456-426614174000", AcsSystemId: "123
 
 ## Request Parameters
 
+### `acs_system_id`
+
+Type: `string`
+Required: Yes
+
+ID of the `acs_system` to which to add the new `acs_user`.
+
+***
+
+### `full_name`
+
+Type: `string`
+Required: Yes
+
+Full name of the new `acs_user`.
+
+***
+
 ### `access_schedule`
 
 Type: `object`
@@ -206,15 +224,6 @@ Array of `access_group_id`s to indicate the access groups to which to add the ne
 
 ***
 
-### `acs_system_id`
-
-Type: `string`
-Required: Yes
-
-ID of the `acs_system` to which to add the new `acs_user`.
-
-***
-
 ### `email`
 
 Type: `string`
@@ -230,15 +239,6 @@ Type: `string`
 Required: No
 
 Email address of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).
-
-***
-
-### `full_name`
-
-Type: `string`
-Required: Yes
-
-Full name of the new `acs_user`.
 
 ***
 

--- a/docs/api/acs/users/update.md
+++ b/docs/api/acs/users/update.md
@@ -126,21 +126,21 @@ nil
 
 ## Request Parameters
 
-### `access_schedule`
-
-Type: `object`
-Required: No
-
-`starts_at` and `ends_at` timestamps for the `acs_user`'s access. If you specify an `access_schedule`, you must include both `starts_at` and `ends_at`. `ends_at` must be a time in the future and after `starts_at`.
-
-***
-
 ### `acs_user_id`
 
 Type: `string`
 Required: Yes
 
 ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).
+
+***
+
+### `access_schedule`
+
+Type: `object`
+Required: No
+
+`starts_at` and `ends_at` timestamps for the `acs_user`'s access. If you specify an `access_schedule`, you must include both `starts_at` and `ends_at`. `ends_at` must be a time in the future and after `starts_at`.
 
 ***
 

--- a/docs/api/phones/simulate/create_sandbox_phone.md
+++ b/docs/api/phones/simulate/create_sandbox_phone.md
@@ -14,6 +14,15 @@ Creates a new simulated phone in a [sandbox workspace](../../../core-concepts/wo
 
 ## Request Parameters
 
+### `user_identity_id`
+
+Type: `string`
+Required: Yes
+
+ID of the user identity to associate with the simulated phone.
+
+***
+
 ### `assa_abloy_metadata`
 
 Type: `object`
@@ -38,15 +47,6 @@ Type: `object`
 Required: No
 
 Metadata to associate with the simulated phone.
-
-***
-
-### `user_identity_id`
-
-Type: `string`
-Required: Yes
-
-ID of the user identity to associate with the simulated phone.
 
 ***
 

--- a/docs/api/thermostats/cool.md
+++ b/docs/api/thermostats/cool.md
@@ -147,6 +147,15 @@ api.ActionAttempt{ActionAttemptId: "123e4567-e89b-12d3-a456-426614174000", Statu
 
 ## Request Parameters
 
+### `device_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired thermostat device.
+
+***
+
 ### `cooling_set_point_celsius`
 
 Type: `number`
@@ -162,15 +171,6 @@ Type: `number`
 Required: No
 
 Desired [cooling set point](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md) in °F. You must set one of the `cooling_set_point` parameters.
-
-***
-
-### `device_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired thermostat device.
 
 ***
 

--- a/docs/api/thermostats/create_climate_preset.md
+++ b/docs/api/thermostats/create_climate_preset.md
@@ -165,6 +165,15 @@ Unique key to identify the [climate preset](../../capability-guides/thermostats/
 
 ***
 
+### `device_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired thermostat device.
+
+***
+
 ### `cooling_set_point_celsius`
 
 Type: `number`
@@ -180,15 +189,6 @@ Type: `number`
 Required: No
 
 Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-
-***
-
-### `device_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired thermostat device.
 
 ***
 

--- a/docs/api/thermostats/heat_cool.md
+++ b/docs/api/thermostats/heat_cool.md
@@ -153,6 +153,15 @@ api.ActionAttempt{ActionAttemptId: "123e4567-e89b-12d3-a456-426614174000", Statu
 
 ## Request Parameters
 
+### `device_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired thermostat device.
+
+***
+
 ### `cooling_set_point_celsius`
 
 Type: `number`
@@ -168,15 +177,6 @@ Type: `number`
 Required: No
 
 Desired [cooling set point](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md) in °F. You must set one of the `cooling_set_point` parameters.
-
-***
-
-### `device_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired thermostat device.
 
 ***
 

--- a/docs/api/thermostats/schedules/create.md
+++ b/docs/api/thermostats/schedules/create.md
@@ -216,6 +216,15 @@ Date and time at which the thermostat schedule ends, in [ISO 8601](https://www.i
 
 ***
 
+### `starts_at`
+
+Type: `string`
+Required: Yes
+
+Date and time at which the thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
+***
+
 ### `is_override_allowed`
 
 Type: `boolean`
@@ -240,15 +249,6 @@ Type: `string`
 Required: No
 
 User-friendly name to identify the thermostat schedule.
-
-***
-
-### `starts_at`
-
-Type: `string`
-Required: Yes
-
-Date and time at which the thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
 
 ***
 

--- a/docs/api/thermostats/schedules/update.md
+++ b/docs/api/thermostats/schedules/update.md
@@ -128,6 +128,15 @@ nil
 
 ## Request Parameters
 
+### `thermostat_schedule_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired thermostat schedule.
+
+***
+
 ### `climate_preset_key`
 
 Type: `string`
@@ -179,15 +188,6 @@ Type: `string`
 Required: No
 
 Date and time at which the thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-
-***
-
-### `thermostat_schedule_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired thermostat schedule.
 
 ***
 

--- a/docs/api/thermostats/update_climate_preset.md
+++ b/docs/api/thermostats/update_climate_preset.md
@@ -145,6 +145,24 @@ Unique key to identify the [climate preset](../../capability-guides/thermostats/
 
 ***
 
+### `device_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired thermostat device.
+
+***
+
+### `manual_override_allowed`
+
+Type: `boolean`
+Required: Yes
+
+Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+
+***
+
 ### `cooling_set_point_celsius`
 
 Type: `number`
@@ -160,15 +178,6 @@ Type: `number`
 Required: No
 
 Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-
-***
-
-### `device_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired thermostat device.
 
 ***
 
@@ -205,15 +214,6 @@ Type: `string`
 Required: No
 
 Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-
-***
-
-### `manual_override_allowed`
-
-Type: `boolean`
-Required: Yes
-
-Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
 
 ***
 

--- a/docs/api/user_identities/enrollment_automations/launch.md
+++ b/docs/api/user_identities/enrollment_automations/launch.md
@@ -180,6 +180,24 @@ api.Unknown{UserIdentityId: "5c945ab5-c75e-4bcb-8e5f-9410061c401f", EnrollmentAu
 
 ## Request Parameters
 
+### `credential_manager_acs_system_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired ACS system that serves as the credential manager.
+
+***
+
+### `user_identity_id`
+
+Type: `string`
+Required: Yes
+
+ID of the desired user identity.
+
+***
+
 ### `acs_credential_pool_id`
 
 Type: `string`
@@ -198,30 +216,12 @@ Indicates whether to create an associated credential manager user. If you set `c
 
 ***
 
-### `credential_manager_acs_system_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired ACS system that serves as the credential manager.
-
-***
-
 ### `credential_manager_acs_user_id`
 
 Type: `string`
 Required: No
 
 ID of the associated ACS user within the credential manager. If you specify a `credential_manager_acs_user_id`, you cannot set `create_credential_manager_user` to `true`.
-
-***
-
-### `user_identity_id`
-
-Type: `string`
-Required: Yes
-
-ID of the desired user identity.
 
 ***
 

--- a/docs/api/user_identities/update.md
+++ b/docs/api/user_identities/update.md
@@ -14,6 +14,15 @@ PATCH /user_identities/update ⇒ void
 
 ## Request Parameters
 
+### `user_identity_id`
+
+Type: `string`
+Required: Yes
+
+ID of the user identity.
+
+***
+
 ### `email_address`
 
 Type: `string`
@@ -38,15 +47,6 @@ Type: `string`
 Required: No
 
 Unique phone number for the user identity in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, +15555550100).
-
-***
-
-### `user_identity_id`
-
-Type: `string`
-Required: Yes
-
-ID of the user identity.
 
 ***
 

--- a/src/lib/layout/api-endpoint.ts
+++ b/src/lib/layout/api-endpoint.ts
@@ -102,7 +102,12 @@ export function setEndpointLayoutContext(
         required: param.isRequired,
         description: param.description,
         jsonType: param.jsonType,
-      })),
+      }))
+      .sort((a, b) => {
+        if (a.required && !b.required) return -1
+        if (!a.required && b.required) return 1
+        return a.name.localeCompare(b.name)
+      }),
   }
 
   file.response = {


### PR DESCRIPTION
Closes https://linear.app/seam/issue/CX-233/show-required-params-above-non-required-params-in-docs

Here is an example of a param that's now sorted by required prop:

https://github.com/seamapi/docs/pull/539/files#diff-cb4e500e26784305a5c54ddb0210922ea4928e0907d90e22461d3d211a4bad13R17

![CleanShot 2025-03-24 at 18 12 05@2x](https://github.com/user-attachments/assets/21ff7d04-d67d-436e-af62-f9b4c05c57d5)

