### PR TITLE
fix: separate properties with ---

### DIFF
--- a/src/layouts/api-route.hbs
+++ b/src/layouts/api-route.hbs
@@ -49,7 +49,7 @@
 <summary>Properties</summary>
 {{#each properties}}
 
-- {{> property-nested this}}
+{{> property-nested this isLast=@last}}
 {{/each}}
 </details>
 

--- a/src/layouts/partials/property-collapsible.hbs
+++ b/src/layouts/partials/property-collapsible.hbs
@@ -3,3 +3,8 @@
 <summary><b><code>{{name}}</code></b> <i>{{format}}</i>{{#if listItemFormat}} <i>of {{listItemFormat}}s</i>{{/if}}</summary>
 {{> property-content}}
 </details>
+{{#unless isLast}}
+
+---
+{{/unless}}
+


### PR DESCRIPTION
Follow up for https://github.com/seamapi/docs/pull/596.

Addresses [comment](https://github.com/seamapi/docs/pull/596#issuecomment-2896503465): 
> it looks like some child props are being rendered as bulleted lists and some as horizontal line-separated lists with no bullets. Let's pick one and use it throughout. I think I prefer the hr-separated lists with no bullets, but I'm not totally sure.

Updates properties to be separated with `---`.

I've left child properties as is (with bullet list).