### PR TITLE
fix: child object properties missing line-breaks

### DIFF
--- a/docs/api/acs/access_groups/README.md
+++ b/docs/api/acs/access_groups/README.md
@@ -159,12 +159,15 @@ Warnings associated with the `acs_access_group`.
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>created_at</code></strong> <i>Datetime</i>
   
     Date and time at which Seam created the warning.
+
   <strong><code>message</code></strong> <i>String</i>
   
     Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+
   <strong><code>warning_code</code></strong> <i>Enum</i>
   
     Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.

--- a/docs/api/acs/credentials/README.md
+++ b/docs/api/acs/credentials/README.md
@@ -182,7 +182,9 @@ Errors associated with the [credential](../../../capability-guides/access-system
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>error_code</code></strong> <i>String</i>
+
   <strong><code>message</code></strong> <i>String</i>
 </details>
 

--- a/docs/api/acs/encoders/README.md
+++ b/docs/api/acs/encoders/README.md
@@ -86,9 +86,11 @@ Errors associated with the [encoder](../../../capability-guides/access-systems/w
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>created_at</code></strong> <i>Datetime</i>
   
     Date and time at which Seam created the error.
+
   <strong><code>error_code</code></strong> <i>Enum</i>
   
     Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
@@ -97,6 +99,7 @@ Errors associated with the [encoder](../../../capability-guides/access-systems/w
   
       - <code>acs_encoder_removed`</code>
   </details>
+
   <strong><code>message</code></strong> <i>String</i>
   
     Detailed description of the error. Provides insights into the issue and potentially how to rectify it.

--- a/docs/api/acs/entrances/README.md
+++ b/docs/api/acs/entrances/README.md
@@ -126,9 +126,11 @@ Errors associated with the [entrance](../../../capability-guides/access-systems/
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>error_code</code></strong> <i>String</i>
   
     Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+
   <strong><code>message</code></strong> <i>String</i>
   
     Detailed description of the error. Provides insights into the issue and potentially how to rectify it.

--- a/docs/api/phones/README.md
+++ b/docs/api/phones/README.md
@@ -96,7 +96,9 @@ Errors associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>error_code</code></strong> <i>String</i>
+
   <strong><code>message</code></strong> <i>String</i>
 </details>
 
@@ -120,7 +122,9 @@ Warnings associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>message</code></strong> <i>String</i>
+
   <strong><code>warning_code</code></strong> <i>String</i>
 </details>
 

--- a/docs/api/thermostats/schedules/README.md
+++ b/docs/api/thermostats/schedules/README.md
@@ -78,9 +78,11 @@ Errors associated with the [thermostat schedule](../../../capability-guides/ther
 
 <details>
   <summary>Child Object Properties</summary>
+
   <strong><code>error_code</code></strong> <i>String</i>
   
     Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+
   <strong><code>message</code></strong> <i>String</i>
   
     Detailed description of the error. Provides insights into the issue and potentially how to rectify it.

--- a/src/layouts/partials/api-resource.hbs
+++ b/src/layouts/partials/api-resource.hbs
@@ -116,8 +116,8 @@ This variant has no additional specific properties.
 {{#if listProperties}}
 <details>
   <summary>Child Object Properties</summary>
-
   {{#each listProperties}}
+
   {{> property-nested this}}
   {{/each}}
 </details>

--- a/src/layouts/partials/api-resource.hbs
+++ b/src/layouts/partials/api-resource.hbs
@@ -116,6 +116,7 @@ This variant has no additional specific properties.
 {{#if listProperties}}
 <details>
   <summary>Child Object Properties</summary>
+
   {{#each listProperties}}
   {{> property-nested this}}
   {{/each}}


### PR DESCRIPTION
Closes https://linear.app/seam/issue/CX-330/line-break-missing-in-child-props

Added a new line before each `> property-nested`

### Before 

https://docs.seam.co/latest/api/acs/credentials

![CleanShot 2025-06-04 at 15 00 45@2x](https://github.com/user-attachments/assets/b2a53489-e841-4a30-a650-e6c6465ca481)

### After

https://docs.seam.co/latest/~/revisions/DFdrUdS2jQOnbJTNDT5a/api/acs/credentials

![CleanShot 2025-06-04 at 15 00 29@2x](https://github.com/user-attachments/assets/5167b47d-b4e9-4733-afc6-4459ea0f6692)


