### PR TITLE
Update body to parameters in code samples

### DIFF
--- a/src/data/code-sample-definitions/access_codes.yaml
+++ b/src/data/code-sample-definitions/access_codes.yaml
@@ -3,7 +3,7 @@
   description: Creates a new ongoing online access code.
   request:
     path: /access_codes/create
-    body:
+    parameters:
       device_id: a5036385-adcb-41b5-88c2-dd8a702a0730
       name: My Ongoing Online Access Code
       code: '1234'
@@ -33,7 +33,7 @@
   description: Creates a new time-bound online access code.
   request:
     path: /access_codes/create
-    body:
+    parameters:
       device_id: a5036385-adcb-41b5-88c2-dd8a702a0730
       name: My Time-Bound Online Access Code
       starts_at: '2025-06-20T06:49:21.000Z'
@@ -67,7 +67,7 @@
   description: Creates a new time-bound offline access code.
   request:
     path: /access_codes/create
-    body:
+    parameters:
       device_id: a5036385-adcb-41b5-88c2-dd8a702a0730
       name: My Time-Bound Offline Access Code
       starts_at: '2025-06-20T06:49:21.000Z'
@@ -105,7 +105,7 @@
   description: Creates a new one-time-use offline access code.
   request:
     path: /access_codes/create
-    body:
+    parameters:
       device_id: a5036385-adcb-41b5-88c2-dd8a702a0730
       name: My One-Time-Use Offline Access Code
       starts_at: '2025-06-20T06:49:21.000Z'
@@ -143,7 +143,7 @@
   description: Creates a new time-bound online access code with a backup access code pool.
   request:
     path: /access_codes/create
-    body:
+    parameters:
       device_id: a5036385-adcb-41b5-88c2-dd8a702a0730
       name: My Time-Bound Access Code
       starts_at: '2025-06-20T06:49:21.000Z'
@@ -178,7 +178,7 @@
   description: Creates new access codes that share a common code across multiple devices.
   request:
     path: /access_codes/create_multiple
-    body:
+    parameters:
       device_ids:
         - d9717800-fa73-401a-b66b-03f0ef950e2a
         - 550e8400-e29b-41d4-a716-446655440000
@@ -215,7 +215,7 @@
   description: Deletes an access code.
   request:
     path: /access_codes/delete
-    body:
+    parameters:
       device_id: d33f4cc7-2b6a-41a4-ad30-c372ee493589
       access_code_id: 275b40a3-6b0b-4c51-8fd2-aafd3de2195c
   response:
@@ -300,7 +300,7 @@
   description: Retrieves a backup access code for an access code.
   request:
     path: /access_codes/pull_backup_access_code
-    body:
+    parameters:
       access_code_id: 8e525b87-5e4b-48a5-a322-5d45262a735f
   response:
     body:
@@ -352,7 +352,7 @@
   description: Enables you to report access code-related constraints for a device.
   request:
     path: /access_codes/report_device_constraints
-    body:
+    parameters:
       device_id: cd17e797-e952-47a1-ba47-46bf72934181
       supported_code_lengths: [4, 5, 6]
       min_code_length: 42
@@ -363,7 +363,7 @@
   description: Enables you to report access code-related constraints for a device.
   request:
     path: /access_codes/report_device_constraints
-    body:
+    parameters:
       device_id: cd17e797-e952-47a1-ba47-46bf72934181
       min_code_length: 4
       max_code_length: 6
@@ -373,7 +373,7 @@
   description: Updates a specified active or upcoming access code.
   request:
     path: /access_codes/update
-    body:
+    parameters:
       access_code_id: b854d7c9-d0d8-40a7-8a7c-cd3d167a6ce5
       name: My Updated Access Code
       starts_at: '2025-06-19T08:26:41.000Z'
@@ -385,7 +385,7 @@
   description: Updates access codes that share a common code across multiple devices.
   request:
     path: /access_codes/update_multiple
-    body:
+    parameters:
       ends_at: '2025-06-22T05:05:47.000Z'
       starts_at: '2025-06-18T19:14:13.000Z'
       name: My Updated Linked Access Code
@@ -396,7 +396,7 @@
   description: Simulates the creation of an unmanaged access code in a sandbox workspace.
   request:
     path: /access_codes/simulate/create_unmanaged_access_code
-    body:
+    parameters:
       device_id: 5db6ef75-2e0d-4491-bf7e-c3eb01d5c963
       name: My Access Code
       code: '1234'
@@ -419,7 +419,7 @@
   description: Converts an unmanaged access code to an access code managed through Seam.
   request:
     path: /access_codes/unmanaged/convert_to_managed
-    body:
+    parameters:
       access_code_id: 9ef2af02-e335-4b49-bd51-00e851a83ef6
       is_external_modification_allowed: true
       force: true
@@ -429,7 +429,7 @@
   description: Deletes an unmanaged access code.
   request:
     path: /access_codes/unmanaged/delete
-    body:
+    parameters:
       access_code_id: 95d54d42-477b-49d6-bd3a-5e8a40a5a78f
   response:
     body: null
@@ -479,7 +479,7 @@
   description: Updates a specified unmanaged access code.
   request:
     path: /access_codes/unmanaged/update
-    body:
+    parameters:
       access_code_id: ebd8e488-db1b-4f4b-9d02-489fbfa6829a
       is_managed: true
       is_external_modification_allowed: true

--- a/src/data/code-sample-definitions/access_grants.yaml
+++ b/src/data/code-sample-definitions/access_grants.yaml
@@ -3,7 +3,7 @@
   description: Creates a new access grant using space IDs and an existing user identity.
   request:
     path: /access_grants/create
-    body:
+    parameters:
       user_identity_id: e3d736c1-540d-4d10-83e5-9a4e135453b4
       space_ids:
         - 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
@@ -51,7 +51,7 @@
   description: Creates a new access grant using entrance IDs and device IDs and an existing user identity.
   request:
     path: /access_grants/create
-    body:
+    parameters:
       user_identity_id: e3d736c1-540d-4d10-83e5-9a4e135453b4
       acs_entrance_ids:
         - f47ac10b-58cc-4372-a567-0e02b2c3d479
@@ -99,7 +99,7 @@
   description: Creates a new access grant and create a new user identity as part of the same operation.
   request:
     path: /access_grants/create
-    body:
+    parameters:
       user_identity:
         full_name: Jane Doe
         email_address: jane.doe@example.com
@@ -240,7 +240,7 @@
   description: Updates an existing access grant's time window.
   request:
     path: /access_grants/update
-    body:
+    parameters:
       access_grant_id: 4ec65722-bf38-4b2f-b4c8-f488aa6ba3f1
       starts_at: '2025-06-19T18:01:32.000Z'
       ends_at: '2025-06-22T13:24:50.000Z'

--- a/src/data/code-sample-definitions/acs.yaml
+++ b/src/data/code-sample-definitions/acs.yaml
@@ -3,7 +3,7 @@
   description: Adds a specified access system user to a specified access group.
   request:
     path: /acs/access_groups/add_user
-    body:
+    parameters:
       acs_access_group_id: 55efa954-2b84-42af-8d05-fc1f892df51c
       acs_user_id: ebf54c67-746c-471f-a03f-86665148a84c
   response:
@@ -12,7 +12,7 @@
   description: Adds a specified access system user to a specified access group, using the associated user identity.
   request:
     path: /acs/access_groups/add_user
-    body:
+    parameters:
       acs_access_group_id: 55efa954-2b84-42af-8d05-fc1f892df51c
       user_identity_id: 522d1368-973f-430f-92df-4ff3583ebccf
   response:
@@ -145,7 +145,7 @@
   description: Removes a specified access system user from a specified access group, using the associated user identity.
   request:
     path: /acs/access_groups/remove_user
-    body:
+    parameters:
       acs_access_group_id: e320069d-59ba-4adb-a465-f4f01a833e07
       user_identity_id: 3d662a00-5d7c-41b4-aee7-16c385964149
   response:
@@ -154,7 +154,7 @@
   description: Removes a specified access system user from a specified access group.
   request:
     path: /acs/access_groups/remove_user
-    body:
+    parameters:
       acs_access_group_id: e320069d-59ba-4adb-a465-f4f01a833e07
       acs_user_id: 64cfac1f-61c0-4c76-8fa2-3e9ab680edc8
   response:
@@ -163,7 +163,7 @@
   description: Assigns a specified credential to a specified access system user, using the associated user identity.
   request:
     path: /acs/credentials/assign
-    body:
+    parameters:
       user_identity_id: 1082e2e8-ecbd-4ef1-aa61-a805f7ae2f01
       acs_credential_id: 59c9af06-7881-46d2-8d9b-3eda964c058b
   response:
@@ -172,7 +172,7 @@
   description: Assigns a specified credential to a specified access system user.
   request:
     path: /acs/credentials/assign
-    body:
+    parameters:
       acs_user_id: 143f083a-d61c-4d85-923f-d5483fb5a7d4
       acs_credential_id: 59c9af06-7881-46d2-8d9b-3eda964c058b
   response:
@@ -181,7 +181,7 @@
   description: Creates a new PIN code credential for a specified access system user, using the associated user identity.
   request:
     path: /acs/credentials/create
-    body:
+    parameters:
       credential_manager_acs_system_id: bccb0d23-5107-498b-87a6-6a8aa929eeb2
       user_identity_id: 4b6ec19d-ba68-46ca-80fd-55247684c2bb
       acs_system_id: 7113de29-6130-4153-a6ea-1b7ca0fe3198
@@ -216,7 +216,7 @@
   description: Creates a new PIN code credential for a specified access system user.
   request:
     path: /acs/credentials/create
-    body:
+    parameters:
       credential_manager_acs_system_id: bccb0d23-5107-498b-87a6-6a8aa929eeb2
       acs_user_id: 53f39f90-5113-4bdd-8432-acf328ce508c
       acs_system_id: 7113de29-6130-4153-a6ea-1b7ca0fe3198
@@ -251,7 +251,7 @@
   description: Creates a new card credential for a specified access system user, using the associated user identity.
   request:
     path: /acs/credentials/create
-    body:
+    parameters:
       credential_manager_acs_system_id: bccb0d23-5107-498b-87a6-6a8aa929eeb2
       user_identity_id: 4b6ec19d-ba68-46ca-80fd-55247684c2bb
       acs_system_id: 7113de29-6130-4153-a6ea-1b7ca0fe3198
@@ -287,7 +287,7 @@
   description: Creates a new card credential for a specified access system user.
   request:
     path: /acs/credentials/create
-    body:
+    parameters:
       credential_manager_acs_system_id: bccb0d23-5107-498b-87a6-6a8aa929eeb2
       acs_user_id: 53f39f90-5113-4bdd-8432-acf328ce508c
       acs_system_id: 7113de29-6130-4153-a6ea-1b7ca0fe3198
@@ -323,7 +323,7 @@
   description: Creates a new mobile key credential for a specified access system user, using the associated user identity.
   request:
     path: /acs/credentials/create
-    body:
+    parameters:
       credential_manager_acs_system_id: bccb0d23-5107-498b-87a6-6a8aa929eeb2
       user_identity_id: 4b6ec19d-ba68-46ca-80fd-55247684c2bb
       acs_system_id: 7113de29-6130-4153-a6ea-1b7ca0fe3198
@@ -357,7 +357,7 @@
   description: Creates a new mobile key credential for a specified access system user.
   request:
     path: /acs/credentials/create
-    body:
+    parameters:
       credential_manager_acs_system_id: bccb0d23-5107-498b-87a6-6a8aa929eeb2
       acs_user_id: 53f39f90-5113-4bdd-8432-acf328ce508c
       acs_system_id: 7113de29-6130-4153-a6ea-1b7ca0fe3198
@@ -391,7 +391,7 @@
   description: Creates a new offline code credential for a specified access system user.
   request:
     path: /acs/credentials/create_offline_code
-    body:
+    parameters:
       acs_user_id: c52072ef-365c-4325-ba78-251239441f4c
       allowed_acs_entrance_id: a420ee23-dceb-42f3-9992-6cf1245f65da
       is_one_time_use: true
@@ -422,7 +422,7 @@
   description: Deletes a specified credential.
   request:
     path: /acs/credentials/delete
-    body:
+    parameters:
       acs_credential_id: 33bbceea-221e-48bd-8d38-aa72f88a1cab
   response:
     body: null
@@ -503,7 +503,7 @@
   description: Unassigns a specified credential from a specified access system user, using the associated user identity ID.
   request:
     path: /acs/credentials/unassign
-    body:
+    parameters:
       user_identity_id: 417e9370-d2cc-4b23-b6d5-fbf7fdbda354
       acs_credential_id: b1833efd-0669-4a88-81b5-2f2d5fd5c02f
   response:
@@ -512,7 +512,7 @@
   description: Unassigns a specified credential from a specified access system user.
   request:
     path: /acs/credentials/unassign
-    body:
+    parameters:
       acs_user_id: ae76d550-f2e0-4f61-9380-a64d276f9904
       acs_credential_id: b1833efd-0669-4a88-81b5-2f2d5fd5c02f
   response:
@@ -521,7 +521,7 @@
   description: Updates the code and ends at date and time for a specified credential.
   request:
     path: /acs/credentials/update
-    body:
+    parameters:
       acs_credential_id: 1d4fb22b-743b-492f-ad74-cffcbd63c874
       code: '1234'
       ends_at: '2025-06-18T10:42:53.000Z'
@@ -531,7 +531,7 @@
   description: Encodes an existing access method onto a plastic card placed on the specified encoder.
   request:
     path: /acs/encoders/encode_access_method
-    body:
+    parameters:
       acs_encoder_id: c49a6fb0-d5a0-4b1e-9553-f32ac550a3c5
       access_method_id: f608c1c7-95df-433d-a449-10becae931be
   response:
@@ -554,7 +554,7 @@
   description: Encodes an existing credential onto a plastic card placed on the specified encoder.
   request:
     path: /acs/encoders/encode_credential
-    body:
+    parameters:
       acs_encoder_id: 18ad521a-308e-4182-b1a6-2338b46a2763
       acs_credential_id: a383871c-331a-42ae-af66-146824505187
   response:
@@ -628,7 +628,7 @@
   description: Scans an encoded acs_credential from a plastic card placed on the specified encoder.
   request:
     path: /acs/encoders/scan_credential
-    body:
+    parameters:
       acs_encoder_id: b062df92-91c6-482c-a3f9-6e578f062d36
   response:
     body:
@@ -717,7 +717,7 @@
   description: Grants a specified access system user access to a specified access system entrance, using the associated user identity.
   request:
     path: /acs/entrances/grant_access
-    body:
+    parameters:
       acs_entrance_id: d23d7180-c1ee-4bbe-8630-05df5031ce35
       user_identity_id: c6247b75-f1cb-493a-9915-a85a0b9639ae
   response:
@@ -726,7 +726,7 @@
   description: Grants a specified access system user access to a specified access system entrance.
   request:
     path: /acs/entrances/grant_access
-    body:
+    parameters:
       acs_entrance_id: d23d7180-c1ee-4bbe-8630-05df5031ce35
       acs_user_id: ace1dabe-7a25-4271-8d76-50e74ee4ae1f
   response:
@@ -947,7 +947,7 @@
   description: Adds a specified access system user to a specified access group.
   request:
     path: /acs/users/add_to_access_group
-    body:
+    parameters:
       acs_user_id: 15ce02a8-b145-4c02-adc9-d9d84c8a1177
       acs_access_group_id: 58c8b034-e527-4635-a335-afc74dc79b27
   response:
@@ -956,7 +956,7 @@
   description: Creates a new access system user.
   request:
     path: /acs/users/create
-    body:
+    parameters:
       full_name: Jane Doe
       acs_system_id: dc5c90b2-1aab-40a6-bcaa-4b8924b7ad46
       acs_access_group_ids:
@@ -999,7 +999,7 @@
   description: Deletes a specified access system user and invalidates the access system user's credentials.
   request:
     path: /acs/users/delete
-    body:
+    parameters:
       user_identity_id: 586c225c-b05c-4af4-8679-9c8a46066cce
       acs_system_id: 1c655fbd-ecd7-49fc-a57e-b6fb67bd8d64
   response:
@@ -1008,7 +1008,7 @@
   description: Deletes a specified access system user and invalidates the access system user's credentials.
   request:
     path: /acs/users/delete
-    body:
+    parameters:
       acs_user_id: 8d483a94-5cbc-425a-a6ee-bd9825820c26
   response:
     body: null
@@ -1397,7 +1397,7 @@
   description: Removes a specified access system user from a specified access group, using the associated user identity.
   request:
     path: /acs/users/remove_from_access_group
-    body:
+    parameters:
       user_identity_id: 00ff2781-cce8-4b63-8c65-2b97647d790c
       acs_access_group_id: d192f395-4c68-4c33-af41-97a7df5be576
   response:
@@ -1406,7 +1406,7 @@
   description: Removes a specified access system user from a specified access group.
   request:
     path: /acs/users/remove_from_access_group
-    body:
+    parameters:
       acs_user_id: 6808e2d9-b4eb-4ad8-b200-503877cd1057
       acs_access_group_id: d192f395-4c68-4c33-af41-97a7df5be576
   response:
@@ -1415,7 +1415,7 @@
   description: Revokes access to all entrances for a specified access system user, using the associated user identity.
   request:
     path: /acs/users/revoke_access_to_all_entrances
-    body:
+    parameters:
       user_identity_id: aadb341e-6cd5-4c8b-9561-8f686f84160c
       acs_system_id: d42163f1-ac2d-4c15-a651-5f2e0007b297
   response:
@@ -1424,7 +1424,7 @@
   description: Revokes access to all entrances for a specified access system user.
   request:
     path: /acs/users/revoke_access_to_all_entrances
-    body:
+    parameters:
       acs_user_id: 2520b7a7-5c5b-482e-9db2-11d02f4ea6ce
   response:
     body: null
@@ -1432,7 +1432,7 @@
   description: Suspends a specified access system user, using the associated user identity.
   request:
     path: /acs/users/suspend
-    body:
+    parameters:
       user_identity_id: 73fac667-bd93-4548-add2-e75161d69c7c
       acs_system_id: f2240088-0bc7-4edb-80d1-485bd956ba7d
   response:
@@ -1441,7 +1441,7 @@
   description: Suspends a specified access system user, using the associated user identity.
   request:
     path: /acs/users/suspend
-    body:
+    parameters:
       acs_user_id: 8f934186-1dbc-4098-9f66-d1b202abec9d
   response:
     body: null
@@ -1449,7 +1449,7 @@
   description: Unsuspends a specified suspended access system user, using the associated user identity.
   request:
     path: /acs/users/unsuspend
-    body:
+    parameters:
       user_identity_id: 6a42fbcf-da1a-40f8-8221-596774f97537
       acs_system_id: 264ea3f9-e483-469e-aada-c98c094d5521
   response:
@@ -1458,7 +1458,7 @@
   description: Unsuspends a specified suspended access system user.
   request:
     path: /acs/users/unsuspend
-    body:
+    parameters:
       acs_user_id: 56dd7042-4134-4788-9212-53f25f2939e1
   response:
     body: null
@@ -1466,7 +1466,7 @@
   description: Updates the properties of a specified access system user, using the associated user identity.
   request:
     path: /acs/users/update
-    body:
+    parameters:
       acs_user_id: 5db87499-0b3b-4750-a2e8-341b2af64049
       user_identity_id: b0bbb463-4fad-4b21-a695-952463ea6e93
       acs_system_id: 88ae7b8b-c406-414b-a745-91d9cea661f7
@@ -1483,7 +1483,7 @@
   description: Updates the properties of a specified access system user.
   request:
     path: /acs/users/update
-    body:
+    parameters:
       acs_user_id: 5db87499-0b3b-4750-a2e8-341b2af64049
       access_schedule:
         starts_at: '2025-06-10T15:00:00.000Z'
@@ -1787,7 +1787,7 @@
   description: Simulates that the next attempt to encode a credential using the specified encoder will fail.
   request:
     path: /acs/encoders/simulate/next_credential_encode_will_fail
-    body:
+    parameters:
       acs_encoder_id: 182ea706-8e14-4921-8e57-ee18d5a7de31
       error_code: no_credential_on_encoder
   response:
@@ -1796,7 +1796,7 @@
   description: Simulates that the next attempt to encode a credential using the specified encoder will succeed.
   request:
     path: /acs/encoders/simulate/next_credential_encode_will_succeed
-    body:
+    parameters:
       acs_encoder_id: 182ea706-8e14-4921-8e57-ee18d5a7de31
       scenario: credential_is_issued
   response:
@@ -1805,7 +1805,7 @@
   description: Simulates that the next attempt to scan a credential using the specified encoder will fail.
   request:
     path: /acs/encoders/simulate/next_credential_scan_will_fail
-    body:
+    parameters:
       acs_encoder_id: 182ea706-8e14-4921-8e57-ee18d5a7de31
       error_code: no_credential_on_encoder
   response:
@@ -1814,7 +1814,7 @@
   description: Simulates that the next attempt to scan a credential using the specified encoder will succeed.
   request:
     path: /acs/encoders/simulate/next_credential_scan_will_succeed
-    body:
+    parameters:
       acs_encoder_id: 182ea706-8e14-4921-8e57-ee18d5a7de31
       scenario: credential_exists_on_seam
       acs_credential_id_on_seam: 123e4567-e89b-12d3-a456-426614174000

--- a/src/data/code-sample-definitions/client_sessions.yaml
+++ b/src/data/code-sample-definitions/client_sessions.yaml
@@ -3,7 +3,7 @@
   description: Creates a new client session.
   request:
     path: /client_sessions/create
-    body:
+    parameters:
       customer_id: e387e15f-be27-47ad-881f-4a6fc5460c57
       customer_key: My Company
       user_identifier_key: jane_doe
@@ -33,7 +33,7 @@
   description: Deletes a client session.
   request:
     path: /client_sessions/delete
-    body:
+    parameters:
       client_session_id: d149de35-cfad-46fe-a78e-f71f649e7a37
   response:
     body: null
@@ -85,7 +85,7 @@
   description: Returns a client session with specific characteristics or creates a new client session with these characteristics if it does not yet exist.
   request:
     path: /client_sessions/get_or_create
-    body:
+    parameters:
       user_identifier_key: jane_doe
       connect_webview_ids:
         - 5e297cfe-23df-4638-bb87-08c4f0f8233b
@@ -113,7 +113,7 @@
   description: Grants a client session access to one or more resources, such as Connect Webviews, user identities, and so on.
   request:
     path: /client_sessions/grant_access
-    body:
+    parameters:
       client_session_id: 3ada79d3-2848-4320-b2ef-a82e1e6dafac
       user_identifier_key: jane_doe
       connected_account_ids:
@@ -251,7 +251,7 @@
   description: Revokes a client session.
   request:
     path: /client_sessions/revoke
-    body:
+    parameters:
       client_session_id: 4271352c-6894-4367-8f52-41d565c48f13
   response:
     body: null

--- a/src/data/code-sample-definitions/connect_webviews.yaml
+++ b/src/data/code-sample-definitions/connect_webviews.yaml
@@ -3,7 +3,7 @@
   description: Creates a new Connect Webview that accepts all stable providers.
   request:
     path: /connect_webviews/create
-    body:
+    parameters:
       custom_redirect_url: https://example.com/redirect
       custom_redirect_failure_url: https://example.com/failure-redirect
       customer_id: 8d7a8cc0-2e69-4bc6-85c8-545036fdd5c0
@@ -75,7 +75,7 @@
   description: Creates a new Connect Webview that accepts specific providers.
   request:
     path: /connect_webviews/create
-    body:
+    parameters:
       custom_redirect_url: https://example.com/redirect
       custom_redirect_failure_url: https://example.com/failure-redirect
       customer_id: 8d7a8cc0-2e69-4bc6-85c8-545036fdd5c0
@@ -126,7 +126,7 @@
   description: Deletes a Connect Webview.
   request:
     path: /connect_webviews/delete
-    body:
+    parameters:
       connect_webview_id: 816f796f-636c-46a9-9fef-7f90ca69e771
   response:
     body: null

--- a/src/data/code-sample-definitions/connected_accounts.yaml
+++ b/src/data/code-sample-definitions/connected_accounts.yaml
@@ -3,7 +3,7 @@
   description: Deletes a specified connected account.
   request:
     path: /connected_accounts/delete
-    body:
+    parameters:
       connected_account_id: 35a07a42-4eb2-4080-9bf9-ee08aa2bf62e
   response:
     body: null
@@ -147,7 +147,7 @@
   description: Request a connected account sync attempt for the specified connected account.
   request:
     path: /connected_accounts/sync
-    body:
+    parameters:
       connected_account_id: f886f890-4ca5-4ce5-b248-509cbfb6c279
   response:
     body: null
@@ -155,7 +155,7 @@
   description: Updates a connected account.
   request:
     path: /connected_accounts/update
-    body:
+    parameters:
       connected_account_id: a289aa54-5488-4707-9a4b-eeea4edf311d
       automatically_manage_new_devices: true
       custom_metadata:

--- a/src/data/code-sample-definitions/devices.yaml
+++ b/src/data/code-sample-definitions/devices.yaml
@@ -3,7 +3,7 @@
   description: Deletes a specified device.
   request:
     path: /devices/delete
-    body:
+    parameters:
       device_id: 8c3c4fdf-36e9-40c4-a865-4d9a76688c94
   response:
     body: null
@@ -1387,7 +1387,7 @@
   description: Updates a specified device.
   request:
     path: /devices/update
-    body:
+    parameters:
       device_id: ccfab465-4838-4ff3-af62-97c78e8bf44b
       name: My Updated Device
       is_managed: true
@@ -1884,7 +1884,7 @@
   description: Updates a specified unmanaged device.
   request:
     path: /devices/unmanaged/update
-    body:
+    parameters:
       device_id: 66c3adbf-a0e5-403a-8981-ec5286b5da76
       is_managed: true
   response:
@@ -2049,7 +2049,7 @@
   description: Simulates connecting a device to Seam.
   request:
     path: /devices/simulate/connect
-    body:
+    parameters:
       device_id: 5d703d4f-523f-42af-9439-618415ca651f
   response:
     body: null
@@ -2057,7 +2057,7 @@
   description: Simulates disconnecting a device from Seam.
   request:
     path: /devices/simulate/disconnect
-    body:
+    parameters:
       device_id: a60686b8-f401-452d-9f67-53d139cf6160
   response:
     body: null
@@ -2065,7 +2065,7 @@
   description: Simulates removing a device from Seam.
   request:
     path: /devices/simulate/remove
-    body:
+    parameters:
       device_id: 46757795-11f7-446a-a6cb-779e9f039d7c
   response:
     body: null

--- a/src/data/code-sample-definitions/locks.yaml
+++ b/src/data/code-sample-definitions/locks.yaml
@@ -327,7 +327,7 @@
   description: Locks a lock.
   request:
     path: /locks/lock_door
-    body:
+    parameters:
       device_id: 9a31853e-4db0-4d78-b21d-f50c8dbdb9dc
   response:
     body:
@@ -341,7 +341,7 @@
   description: Unlocks a lock.
   request:
     path: /locks/unlock_door
-    body:
+    parameters:
       device_id: be047431-bf00-4da6-9fc7-0a7796a9b57f
   response:
     body:
@@ -355,7 +355,7 @@
   description: Simulates the entry of a code on a keypad.
   request:
     path: /locks/simulate/keypad_code_entry
-    body:
+    parameters:
       device_id: 97a7a706-05a9-405c-91e5-b03e5b9c2003
       code: '1234'
   response:
@@ -370,7 +370,7 @@
   description: Simulates a manual lock action using a keypad.
   request:
     path: /locks/simulate/manual_lock_via_keypad
-    body:
+    parameters:
       device_id: d0eed522-8c2f-4905-88fd-4fe8b067bedc
   response:
     body:

--- a/src/data/code-sample-definitions/noise_sensors.yaml
+++ b/src/data/code-sample-definitions/noise_sensors.yaml
@@ -151,7 +151,7 @@
   description: Simulates the triggering of a noise threshold for a noise sensor in a sandbox workspace.
   request:
     path: /noise_sensors/simulate/trigger_noise_threshold
-    body:
+    parameters:
       device_id: c0384c1c-9038-427c-9a72-314d2b168d43
   response:
     body: null
@@ -159,7 +159,7 @@
   description: Creates a new noise threshold for a noise sensor.
   request:
     path: /noise_sensors/noise_thresholds/create
-    body:
+    parameters:
       device_id: 8282891b-c4da-4239-8f01-56089d44b80d
       name: My Noise Sensor
       starts_daily_at: '2025-06-20T18:29:57.000Z'
@@ -180,7 +180,7 @@
   description: Deletes a noise threshold from a noise sensor.
   request:
     path: /noise_sensors/noise_thresholds/delete
-    body:
+    parameters:
       noise_threshold_id: 00fbac13-6602-4079-b4ae-c89d5dcbed35
       device_id: 736fc5bf-192d-4416-b879-66ff0195f2f7
   response:
@@ -221,7 +221,7 @@
   description: Updates a noise threshold for a noise sensor.
   request:
     path: /noise_sensors/noise_thresholds/update
-    body:
+    parameters:
       noise_threshold_id: 2cb09850-4962-4dee-a658-d8a79fcb9aff
       device_id: c3885398-6794-44a0-a7a2-1f39ff454dc3
       name: My Updated Noise Sensor

--- a/src/data/code-sample-definitions/phones.yaml
+++ b/src/data/code-sample-definitions/phones.yaml
@@ -3,7 +3,7 @@
   description: Deactivates a phone, which is useful, for example, if a user has lost their phone.
   request:
     path: /phones/deactivate
-    body:
+    parameters:
       device_id: 6481cd6a-579f-4d8c-9adb-b42bf9fb697e
   response:
     body: null
@@ -86,7 +86,7 @@
   description: Creates a new simulated phone in a sandbox workspace.
   request:
     path: /phones/simulate/create_sandbox_phone
-    body:
+    parameters:
       custom_sdk_installation_id: visionline_sdk
       user_identity_id: 799f9914-f2c2-4087-ab34-f1ffb44d6a0b
       phone_metadata:

--- a/src/data/code-sample-definitions/spaces.yaml
+++ b/src/data/code-sample-definitions/spaces.yaml
@@ -3,7 +3,7 @@
   description: Adds entrances to a specific space.
   request:
     path: /spaces/add_acs_entrances
-    body:
+    parameters:
       space_id: 9f930664-c0d8-441b-8d66-2b1d0d2466f4
       acs_entrance_ids:
         - b127a710-db3e-402c-afdf-5474769b1d83
@@ -13,7 +13,7 @@
   description: Adds devices to a specific space.
   request:
     path: /spaces/add_devices
-    body:
+    parameters:
       space_id: 4d53b5c0-87cd-4de9-832d-025e075e7cd4
       device_ids:
         - 22fb4992-463c-4ccd-b568-50fcea243665
@@ -23,7 +23,7 @@
   description: Creates a new space.
   request:
     path: /spaces/create
-    body:
+    parameters:
       name: My Space
       device_ids:
         - b7254403-db91-4e10-bb7b-31d0615d2963
@@ -41,7 +41,7 @@
   description: Deletes a space.
   request:
     path: /spaces/delete
-    body:
+    parameters:
       space_id: a7cd0163-4e94-41ae-b5b7-da6040a65509
   response:
     body: null
@@ -75,7 +75,7 @@
   description: Removes entrances from a specific space.
   request:
     path: /spaces/remove_acs_entrances
-    body:
+    parameters:
       space_id: 674e511a-06c6-4734-b4ce-af467496d5fe
       acs_entrance_ids:
         - fd859a36-199b-4c2f-894a-24d52621f6a4
@@ -85,7 +85,7 @@
   description: Removes devices from a specific space.
   request:
     path: /spaces/remove_devices
-    body:
+    parameters:
       space_id: 6df14344-4114-4d74-9ef4-2e1208378cda
       device_ids:
         - 011460e9-9605-46a5-91f1-6b2a442b70fd
@@ -95,7 +95,7 @@
   description: Updates an existing space.
   request:
     path: /spaces/update
-    body:
+    parameters:
       space_id: d3513c20-dc89-4e19-8713-1c3ab01aec81
       name: My Updated Space
   response:

--- a/src/data/code-sample-definitions/thermostats.yaml
+++ b/src/data/code-sample-definitions/thermostats.yaml
@@ -3,7 +3,7 @@
   description: Activates a specified climate preset for a specified thermostat.
   request:
     path: /thermostats/activate_climate_preset
-    body:
+    parameters:
       device_id: 52b88155-5b81-47d2-b04d-28a802bd7395
       climate_preset_key: Eco
   response:
@@ -18,7 +18,7 @@
   description: Sets a specified thermostat to cool mode.
   request:
     path: /thermostats/cool
-    body:
+    parameters:
       device_id: 408641ab-d0f5-475c-b8a5-9b9096405f9a
       cooling_set_point_fahrenheit: 75
   response:
@@ -33,7 +33,7 @@
   description: Creates a climate preset for a specified thermostat.
   request:
     path: /thermostats/create_climate_preset
-    body:
+    parameters:
       device_id: ba9b816d-c255-46b9-a16d-971e6f535dd3
       manual_override_allowed: true
       climate_preset_key: Occupied
@@ -48,7 +48,7 @@
   description: Deletes a specified climate preset for a specified thermostat.
   request:
     path: /thermostats/delete_climate_preset
-    body:
+    parameters:
       device_id: 88cb2f5b-b01b-43f2-b84f-81e2fa1d09c5
       climate_preset_key: Eco
   response:
@@ -385,7 +385,7 @@
   description: Sets a specified thermostat to heat mode.
   request:
     path: /thermostats/heat
-    body:
+    parameters:
       device_id: e4b111b8-e2bd-4f49-a9c8-96ed5390e1d5
       heating_set_point_fahrenheit: 65
   response:
@@ -400,7 +400,7 @@
   description: Sets a specified thermostat to heat-cool ("auto") mode.
   request:
     path: /thermostats/heat_cool
-    body:
+    parameters:
       device_id: 32f974cc-e817-4bd7-b7f1-be92c80884a1
       heating_set_point_celsius: 20
       cooling_set_point_celsius: 25
@@ -736,7 +736,7 @@
   description: Sets a specified thermostat to "off" mode.
   request:
     path: /thermostats/off
-    body:
+    parameters:
       device_id: 5d5c3b30-5fed-47a3-9df1-ed32f32589e5
   response:
     body:
@@ -750,7 +750,7 @@
   description: Sets a specified climate preset as the "fallback" preset for a specified thermostat.
   request:
     path: /thermostats/set_fallback_climate_preset
-    body:
+    parameters:
       device_id: 9a21ddcb-8eeb-4351-8770-1835c3db8b2e
       climate_preset_key: Eco
   response:
@@ -759,7 +759,7 @@
   description: Sets the fan mode setting for a specified thermostat.
   request:
     path: /thermostats/set_fan_mode
-    body:
+    parameters:
       device_id: 363e657e-3b07-4670-a290-7fb1f32b8e33
       fan_mode_setting: auto
   response:
@@ -774,7 +774,7 @@
   description: Sets the HVAC mode for a specified thermostat.
   request:
     path: /thermostats/set_hvac_mode
-    body:
+    parameters:
       device_id: 5d5c3b30-5fed-47a3-9df1-ed32f32589e5
       hvac_mode_setting: heat_cool
       heating_set_point_celsius: 20
@@ -791,7 +791,7 @@
   description: Sets a temperature threshold for a specified thermostat.
   request:
     path: /thermostats/set_temperature_threshold
-    body:
+    parameters:
       device_id: a9b52627-e6e2-4beb-9168-964749f7bbae
       lower_limit_fahrenheit: 60
       upper_limit_fahrenheit: 80
@@ -801,7 +801,7 @@
   description: Updates a specified climate preset for a specified thermostat.
   request:
     path: /thermostats/update_climate_preset
-    body:
+    parameters:
       device_id: a2495670-80a5-4c98-b8c0-8b0c9d49c3b8
       climate_preset_key: Home
       name: Home
@@ -816,7 +816,7 @@
   description: Updates the thermostat weekly program for a thermostat device.
   request:
     path: /thermostats/update_weekly_program
-    body:
+    parameters:
       device_id: 076546e8-966c-47dd-831b-8d98413bf070
       monday_program_id: a36dccaa-aeb9-47da-bf1d-43a08ba5c870
       tuesday_program_id: a36dccaa-aeb9-47da-bf1d-43a08ba5c870
@@ -837,7 +837,7 @@
   description: Creates a new thermostat schedule for a specified thermostat.
   request:
     path: /thermostats/schedules/create
-    body:
+    parameters:
       device_id: d710aa35-232d-442b-a817-c28045de1c74
       name: "Jane's Stay"
       climate_preset_key: Occupied
@@ -863,7 +863,7 @@
   description: Deletes a thermostat schedule for a specified thermostat.
   request:
     path: /thermostats/schedules/delete
-    body:
+    parameters:
       thermostat_schedule_id: 0d42131f-ceb2-4fdf-b44e-3cc1143f98de
   response:
     body: null
@@ -931,7 +931,7 @@
   description: Updates a specified thermostat schedule.
   request:
     path: /thermostats/schedules/update
-    body:
+    parameters:
       thermostat_schedule_id: f29b8f4d-ef6e-4219-96e5-16fb2151ec6c
       name: "Jane's Stay"
       climate_preset_key: Occupied
@@ -945,7 +945,7 @@
   description: Creates a new thermostat daily program.
   request:
     path: /thermostats/daily_programs/create
-    body:
+    parameters:
       device_id: cc2d0fb9-1f5f-410f-80f1-a64b699de82a
       name: Weekday Program
       periods:
@@ -970,7 +970,7 @@
   description: Deletes a thermostat daily program.
   request:
     path: /thermostats/daily_programs/delete
-    body:
+    parameters:
       thermostat_daily_program_id: a8665859-629e-4696-88b1-1eda1976250a
   response:
     body: null
@@ -978,7 +978,7 @@
   description: Updates a specified thermostat daily program.
   request:
     path: /thermostats/daily_programs/update
-    body:
+    parameters:
       thermostat_daily_program_id: 6baf3a53-ba83-4052-8ea5-143584e18f03
       name: Weekday Program
       periods:
@@ -998,7 +998,7 @@
   description: Simulates having adjusted the HVAC mode for a thermostat.
   request:
     path: /thermostats/simulate/hvac_mode_adjusted
-    body:
+    parameters:
       device_id: 278a72ba-7deb-45e3-a0c0-573fd360ee7b
       hvac_mode: heat
       heating_set_point_fahrenheit: 68
@@ -1008,7 +1008,7 @@
   description: Simulates a thermostat reaching a specified temperature.
   request:
     path: /thermostats/simulate/temperature_reached
-    body:
+    parameters:
       device_id: 278a72ba-7deb-45e3-a0c0-573fd360ee7b
       temperature_celsius: 25
   response:

--- a/src/data/code-sample-definitions/user_identities.yaml
+++ b/src/data/code-sample-definitions/user_identities.yaml
@@ -3,7 +3,7 @@
   description: Adds a specified access system user to a specified user identity.
   request:
     path: /user_identities/add_acs_user
-    body:
+    parameters:
       user_identity_id: 68dd3d7e-c90b-4c89-ad70-3e589014ed87
       acs_user_id: d73f4706-67e3-419d-899e-ec957a75ee0c
   response:
@@ -12,7 +12,7 @@
   description: Creates a new user identity. By specifying the desired acs_system_id, this operation also creates an access system user for the specified access system if this user does not already exist.
   request:
     path: /user_identities/create
-    body:
+    parameters:
       user_identity_key: 61c6c8ec-21ac-4d1d-be02-688889c66d8c
       email_address: jane@example.com
       phone_number: '+15551234567'
@@ -36,7 +36,7 @@
   description: Deletes a specified user identity.
   request:
     path: /user_identities/delete
-    body:
+    parameters:
       user_identity_id: 7ad2566e-6fd8-466d-b8e4-c10a14a74fd3
   response:
     body: null
@@ -44,7 +44,7 @@
   description: Generates a new instant key for a specified user identity.
   request:
     path: /user_identities/generate_instant_key
-    body:
+    parameters:
       user_identity_id: d92e0c7b-72a1-4063-9ee8-2acefc240358
       max_use_count: 10
   response:
@@ -99,7 +99,7 @@
   description: Grants a specified user identity access to a specified device.
   request:
     path: /user_identities/grant_access_to_device
-    body:
+    parameters:
       user_identity_id: 4e9b7099-bcad-4af6-bb78-88b96cc347bd
       device_id: 6de31c5d-c8a3-4b25-a86b-a9c5075a5eb8
   response:
@@ -526,7 +526,7 @@
   description: Removes a specified access system user from a specified user identity.
   request:
     path: /user_identities/remove_acs_user
-    body:
+    parameters:
       user_identity_id: 802633b6-a66c-4911-b57b-323e900ee531
       acs_user_id: faa22878-fa74-4ea0-87f7-2b05c1b06181
   response:
@@ -535,7 +535,7 @@
   description: Revokes access to a specified device from a specified user identity.
   request:
     path: /user_identities/revoke_access_to_device
-    body:
+    parameters:
       user_identity_id: a5a48343-a95e-4f51-a5d9-1e4241b73553
       device_id: 92874f9e-a2b5-4d49-a039-0280196ad4d5
   response:
@@ -544,7 +544,7 @@
   description: Updates a specified user identity.
   request:
     path: /user_identities/update
-    body:
+    parameters:
       user_identity_id: dc378ea9-358e-4999-b295-d0f3e0d5ff51
       user_identity_key: jane_doe
       email_address: jane@example.com

--- a/src/data/code-sample-definitions/webhooks.yaml
+++ b/src/data/code-sample-definitions/webhooks.yaml
@@ -3,7 +3,7 @@
   description: Creates a new webhook.
   request:
     path: /webhooks/create
-    body:
+    parameters:
       url: https://example.com
       event_types:
         - device.connected
@@ -21,7 +21,7 @@
   description: Deletes a specified webhook.
   request:
     path: /webhooks/delete
-    body:
+    parameters:
       webhook_id: d3fb55d3-8b49-43ed-ac6b-e490be7b4274
   response:
     body: null
@@ -57,7 +57,7 @@
   description: Updates a specified webhook.
   request:
     path: /webhooks/update
-    body:
+    parameters:
       webhook_id: e294905f-e7a5-4804-95a6-303f440eb262
       event_types:
         - device.connected

--- a/src/data/code-sample-definitions/workspaces.yaml
+++ b/src/data/code-sample-definitions/workspaces.yaml
@@ -3,7 +3,7 @@
   description: Creates a new sandbox workspace.
   request:
     path: /workspaces/create
-    body:
+    parameters:
       name: My Sandbox Workspace
       company_name: Acme
       connect_partner_name: Acme
@@ -37,7 +37,7 @@
   description: Creates a new production workspace.
   request:
     path: /workspaces/create
-    body:
+    parameters:
       name: My Production Workspace
       company_name: Acme
       connect_partner_name: Acme
@@ -121,7 +121,7 @@
   description: Updates the workspace associated with the authentication value.
   request:
     path: /workspaces/update
-    body:
+    parameters:
       name: My Workspace
       connect_partner_name: Acme
       connect_webview_customization:


### PR DESCRIPTION
I noticed the render was empty. This is supposed to be parameters for all requests. There isn't really value in having two different names (body and parameters) as the Seam API is RPC style with only a single function argument, e.g., even though the data may sometimes be sent in the body or the query, it's all the same fundamental input.