### PR TITLE
Special layout handling for routes with groups

### DIFF
--- a/src/layouts/partials/api-resource.hbs
+++ b/src/layouts/partials/api-resource.hbs
@@ -1,3 +1,4 @@
+{{#unless hidePreamble}}
 ## The {{name}} Object
 
 - [Properties](./#properties)
@@ -13,6 +14,7 @@
 
 {{description}}
 {{/if}}
+{{/unless}}
 {{#if resourceSamples.length}}
 
 {% tabs %}

--- a/src/lib/layout/api-route.ts
+++ b/src/lib/layout/api-route.ts
@@ -75,6 +75,7 @@ export interface ApiRouteResource {
   propertyGroups: ApiRoutePropertyGroup[]
   legacyPropertyGroups?: ApiRoutePropertyGroup[]
   events: ApiRouteEvent[]
+  hidePreamble: boolean
 }
 
 interface ApiRouteVariantGroup {
@@ -190,6 +191,8 @@ export function setApiRouteLayoutContext(
       ...(legacyPropertyGroups == null ? {} : { legacyPropertyGroups }),
       errorGroups,
       warningGroups,
+      hidePreamble:
+        groupOptions.include != null || groupOptions.exclude != null,
       events: eventsByRoutePath.get(resource.routePath) ?? [],
       resourceSamples: resource.resourceSamples.map(mapResourceSample),
     })

--- a/src/lib/layout/api-route.ts
+++ b/src/lib/layout/api-route.ts
@@ -194,7 +194,21 @@ export function setApiRouteLayoutContext(
       hidePreamble:
         groupOptions.include != null || groupOptions.exclude != null,
       events: eventsByRoutePath.get(resource.routePath) ?? [],
-      resourceSamples: resource.resourceSamples.map(mapResourceSample),
+      resourceSamples: resource.resourceSamples
+        .filter(({ title }) => {
+          if (groupOptions.include != null) {
+            return groupOptions.include.some((x) =>
+              title.toLowerCase().includes(x.split('_')[0]?.slice(0, -1) ?? ''),
+            )
+          }
+          if (groupOptions.exclude != null) {
+            return !groupOptions.exclude.some((x) =>
+              title.toLowerCase().includes(x.split('_')[0]?.slice(0, -1) ?? ''),
+            )
+          }
+          return true
+        })
+        .map(mapResourceSample),
     })
   }
 }


### PR DESCRIPTION
- **Hide preamble for resources on secondary route**
- **Filter resource samples that don't match filters**
