### PR TITLE
fix: child prop description showing as `code`

### DIFF
--- a/docs/api/access_grants/README.md
+++ b/docs/api/access_grants/README.md
@@ -146,28 +146,28 @@ Access methods that the user requested for the Access Grant.
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>created_access_method_ids</code></strong> <i>List</i> <i>of UUIDs</i>
-  
-    IDs of the access methods created for the requested access method.
+<strong><code>created_access_method_ids</code></strong> <i>List</i> <i>of UUIDs</i>
 
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which the requested access method was added to the Access Grant.
+  IDs of the access methods created for the requested access method.
 
-  <strong><code>display_name</code></strong> <i>String</i>
-  
-    Display name of the access method.
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>mode</code></strong> <i>Enum</i>
-  
-    Access method mode. Supported values: `code`, `card`, `mobile_key`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>code</code>
-      - <code>card</code>
-      - <code>mobile_key</code>
-  </details>
+  Date and time at which the requested access method was added to the Access Grant.
+
+<strong><code>display_name</code></strong> <i>String</i>
+
+  Display name of the access method.
+
+<strong><code>mode</code></strong> <i>Enum</i>
+
+  Access method mode. Supported values: `code`, `card`, `mobile_key`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>code</code>
+    - <code>card</code>
+    - <code>mobile_key</code>
+</details>
 
 </details>
 

--- a/docs/api/access_grants/README.md
+++ b/docs/api/access_grants/README.md
@@ -146,29 +146,25 @@ Access methods that the user requested for the Access Grant.
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>created_access_method_ids</code></strong> <i>List</i> <i>of UUIDs</i>
 
-  <strong><code>created_access_method_ids</code></strong> <i>List</i> <i>of UUIDs</i>
-  
-    IDs of the access methods created for the requested access method.
+  IDs of the access methods created for the requested access method.
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which the requested access method was added to the Access Grant.
+  Date and time at which the requested access method was added to the Access Grant.
+<strong><code>display_name</code></strong> <i>String</i>
 
-  <strong><code>display_name</code></strong> <i>String</i>
-  
-    Display name of the access method.
+  Display name of the access method.
+<strong><code>mode</code></strong> <i>Enum</i>
 
-  <strong><code>mode</code></strong> <i>Enum</i>
-  
-    Access method mode. Supported values: `code`, `card`, `mobile_key`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>code</code>
-      - <code>card</code>
-      - <code>mobile_key</code>
-  </details>
+  Access method mode. Supported values: `code`, `card`, `mobile_key`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>code</code>
+    - <code>card</code>
+    - <code>mobile_key</code>
+</details>
 </details>
 
 ---

--- a/docs/api/access_grants/README.md
+++ b/docs/api/access_grants/README.md
@@ -146,25 +146,29 @@ Access methods that the user requested for the Access Grant.
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>created_access_method_ids</code></strong> <i>List</i> <i>of UUIDs</i>
+  <strong><code>created_access_method_ids</code></strong> <i>List</i> <i>of UUIDs</i>
+  
+    IDs of the access methods created for the requested access method.
 
-  IDs of the access methods created for the requested access method.
-<strong><code>created_at</code></strong> <i>Datetime</i>
+  <strong><code>created_at</code></strong> <i>Datetime</i>
+  
+    Date and time at which the requested access method was added to the Access Grant.
 
-  Date and time at which the requested access method was added to the Access Grant.
-<strong><code>display_name</code></strong> <i>String</i>
+  <strong><code>display_name</code></strong> <i>String</i>
+  
+    Display name of the access method.
 
-  Display name of the access method.
-<strong><code>mode</code></strong> <i>Enum</i>
+  <strong><code>mode</code></strong> <i>Enum</i>
+  
+    Access method mode. Supported values: `code`, `card`, `mobile_key`.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>code</code>
+      - <code>card</code>
+      - <code>mobile_key</code>
+  </details>
 
-  Access method mode. Supported values: `code`, `card`, `mobile_key`.
-<details>
-    <summary>Enum values:</summary>
-
-    - <code>code</code>
-    - <code>card</code>
-    - <code>mobile_key</code>
-</details>
 </details>
 
 ---

--- a/docs/api/acs/access_groups/README.md
+++ b/docs/api/acs/access_groups/README.md
@@ -170,23 +170,20 @@ Warnings associated with the `acs_access_group`.
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which Seam created the warning.
+  Date and time at which Seam created the warning.
+<strong><code>message</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+  Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+<strong><code>warning_code</code></strong> <i>Enum</i>
 
-  <strong><code>warning_code</code></strong> <i>Enum</i>
-  
-    Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>unknown_issue_with_acs_access_group</code>
-  </details>
+  Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>unknown_issue_with_acs_access_group</code>
+</details>
 </details>
 
 ---

--- a/docs/api/acs/access_groups/README.md
+++ b/docs/api/acs/access_groups/README.md
@@ -170,20 +170,23 @@ Warnings associated with the `acs_access_group`.
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>created_at</code></strong> <i>Datetime</i>
+  <strong><code>created_at</code></strong> <i>Datetime</i>
+  
+    Date and time at which Seam created the warning.
 
-  Date and time at which Seam created the warning.
-<strong><code>message</code></strong> <i>String</i>
+  <strong><code>message</code></strong> <i>String</i>
+  
+    Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
 
-  Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
-<strong><code>warning_code</code></strong> <i>Enum</i>
+  <strong><code>warning_code</code></strong> <i>Enum</i>
+  
+    Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>unknown_issue_with_acs_access_group</code>
+  </details>
 
-  Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
-<details>
-    <summary>Enum values:</summary>
-
-    - <code>unknown_issue_with_acs_access_group</code>
-</details>
 </details>
 
 ---

--- a/docs/api/acs/access_groups/README.md
+++ b/docs/api/acs/access_groups/README.md
@@ -170,22 +170,22 @@ Warnings associated with the `acs_access_group`.
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which Seam created the warning.
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+  Date and time at which Seam created the warning.
 
-  <strong><code>warning_code</code></strong> <i>Enum</i>
-  
-    Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>unknown_issue_with_acs_access_group</code>
-  </details>
+<strong><code>message</code></strong> <i>String</i>
+
+  Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+
+<strong><code>warning_code</code></strong> <i>Enum</i>
+
+  Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>unknown_issue_with_acs_access_group</code>
+</details>
 
 </details>
 

--- a/docs/api/acs/credentials/README.md
+++ b/docs/api/acs/credentials/README.md
@@ -258,8 +258,10 @@ Errors associated with the [credential](../../../capability-guides/access-system
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>error_code</code></strong> <i>String</i>
-<strong><code>message</code></strong> <i>String</i>
+  <strong><code>error_code</code></strong> <i>String</i>
+
+  <strong><code>message</code></strong> <i>String</i>
+
 </details>
 
 ---

--- a/docs/api/acs/credentials/README.md
+++ b/docs/api/acs/credentials/README.md
@@ -258,10 +258,8 @@ Errors associated with the [credential](../../../capability-guides/access-system
 
 <details>
   <summary>Child Object Properties</summary>
-
-  <strong><code>error_code</code></strong> <i>String</i>
-
-  <strong><code>message</code></strong> <i>String</i>
+<strong><code>error_code</code></strong> <i>String</i>
+<strong><code>message</code></strong> <i>String</i>
 </details>
 
 ---

--- a/docs/api/acs/credentials/README.md
+++ b/docs/api/acs/credentials/README.md
@@ -258,9 +258,9 @@ Errors associated with the [credential](../../../capability-guides/access-system
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>error_code</code></strong> <i>String</i>
+<strong><code>error_code</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
+<strong><code>message</code></strong> <i>String</i>
 
 </details>
 

--- a/docs/api/acs/encoders/README.md
+++ b/docs/api/acs/encoders/README.md
@@ -97,22 +97,22 @@ Errors associated with the [encoder](../../../capability-guides/access-systems/w
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which Seam created the error.
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>error_code</code></strong> <i>Enum</i>
-  
-    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>acs_encoder_removed</code>
-  </details>
+  Date and time at which Seam created the error.
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+<strong><code>error_code</code></strong> <i>Enum</i>
+
+  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>acs_encoder_removed</code>
+</details>
+
+<strong><code>message</code></strong> <i>String</i>
+
+  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 
 </details>
 

--- a/docs/api/acs/encoders/README.md
+++ b/docs/api/acs/encoders/README.md
@@ -97,23 +97,20 @@ Errors associated with the [encoder](../../../capability-guides/access-systems/w
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which Seam created the error.
+  Date and time at which Seam created the error.
+<strong><code>error_code</code></strong> <i>Enum</i>
 
-  <strong><code>error_code</code></strong> <i>Enum</i>
-  
-    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>acs_encoder_removed</code>
-  </details>
+  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+    - <code>acs_encoder_removed</code>
+</details>
+<strong><code>message</code></strong> <i>String</i>
+
+  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 </details>
 
 ---

--- a/docs/api/acs/encoders/README.md
+++ b/docs/api/acs/encoders/README.md
@@ -97,20 +97,23 @@ Errors associated with the [encoder](../../../capability-guides/access-systems/w
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>created_at</code></strong> <i>Datetime</i>
+  <strong><code>created_at</code></strong> <i>Datetime</i>
+  
+    Date and time at which Seam created the error.
 
-  Date and time at which Seam created the error.
-<strong><code>error_code</code></strong> <i>Enum</i>
+  <strong><code>error_code</code></strong> <i>Enum</i>
+  
+    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>acs_encoder_removed</code>
+  </details>
 
-  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>message</code></strong> <i>String</i>
+  
+    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 
-    - <code>acs_encoder_removed</code>
-</details>
-<strong><code>message</code></strong> <i>String</i>
-
-  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 </details>
 
 ---

--- a/docs/api/acs/entrances/README.md
+++ b/docs/api/acs/entrances/README.md
@@ -180,13 +180,13 @@ Errors associated with the [entrance](../../../capability-guides/access-systems/
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>error_code</code></strong> <i>String</i>
-  
-    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+<strong><code>error_code</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+
+<strong><code>message</code></strong> <i>String</i>
+
+  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 
 </details>
 

--- a/docs/api/acs/entrances/README.md
+++ b/docs/api/acs/entrances/README.md
@@ -180,12 +180,14 @@ Errors associated with the [entrance](../../../capability-guides/access-systems/
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>error_code</code></strong> <i>String</i>
+  <strong><code>error_code</code></strong> <i>String</i>
+  
+    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
 
-  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-<strong><code>message</code></strong> <i>String</i>
+  <strong><code>message</code></strong> <i>String</i>
+  
+    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 
-  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 </details>
 
 ---

--- a/docs/api/acs/entrances/README.md
+++ b/docs/api/acs/entrances/README.md
@@ -180,14 +180,12 @@ Errors associated with the [entrance](../../../capability-guides/access-systems/
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>error_code</code></strong> <i>String</i>
 
-  <strong><code>error_code</code></strong> <i>String</i>
-  
-    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+<strong><code>message</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 </details>
 
 ---

--- a/docs/api/devices/README.md
+++ b/docs/api/devices/README.md
@@ -3063,29 +3063,32 @@ Constraints on access codes for the device. Seam represents each constraint as a
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>constraint_type</code></strong> <i>Enum</i>
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>constraint_type</code></strong> <i>Enum</i>
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>no_zeros</code>
+      - <code>cannot_start_with_12</code>
+      - <code>no_triple_consecutive_ints</code>
+      - <code>cannot_specify_pin_code</code>
+      - <code>pin_code_matches_existing_set</code>
+      - <code>start_date_in_future</code>
+      - <code>no_ascending_or_descending_sequence</code>
+      - <code>at_least_three_unique_digits</code>
+      - <code>cannot_contain_089</code>
+      - <code>cannot_contain_0789</code>
+      - <code>name_length</code>
+      - <code>name_must_be_unique</code>
+  </details>
 
-    - <code>no_zeros</code>
-    - <code>cannot_start_with_12</code>
-    - <code>no_triple_consecutive_ints</code>
-    - <code>cannot_specify_pin_code</code>
-    - <code>pin_code_matches_existing_set</code>
-    - <code>start_date_in_future</code>
-    - <code>no_ascending_or_descending_sequence</code>
-    - <code>at_least_three_unique_digits</code>
-    - <code>cannot_contain_089</code>
-    - <code>cannot_contain_0789</code>
-    - <code>name_length</code>
-    - <code>name_must_be_unique</code>
-</details>
-<strong><code>max_length</code></strong> <i>Number</i>
+  <strong><code>max_length</code></strong> <i>Number</i>
+  
+    Maximum name length constraint for access codes.
 
-  Maximum name length constraint for access codes.
-<strong><code>min_length</code></strong> <i>Number</i>
+  <strong><code>min_length</code></strong> <i>Number</i>
+  
+    Minimum name length constraint for access codes.
 
-  Minimum name length constraint for access codes.
 </details>
 
 ---
@@ -3442,95 +3445,113 @@ Available [climate presets](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>can_delete</code></strong> <i>Boolean</i>
+  <strong><code>can_delete</code></strong> <i>Boolean</i>
+  
+    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
 
-  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
-<strong><code>can_edit</code></strong> <i>Boolean</i>
+  <strong><code>can_edit</code></strong> <i>Boolean</i>
+  
+    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
 
-  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
-<strong><code>can_program</code></strong> <i>Boolean</i>
+  <strong><code>can_program</code></strong> <i>Boolean</i>
+  
+    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
 
-  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
-<strong><code>climate_preset_key</code></strong> <i>String</i>
+  <strong><code>climate_preset_key</code></strong> <i>String</i>
+  
+    Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
-<strong><code>climate_preset_mode</code></strong> <i>Enum</i>
+  <strong><code>climate_preset_mode</code></strong> <i>Enum</i>
+  
+    The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>home</code>
+      - <code>away</code>
+      - <code>wake</code>
+      - <code>sleep</code>
+      - <code>occupied</code>
+      - <code>unoccupied</code>
+  </details>
 
-  The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-    - <code>home</code>
-    - <code>away</code>
-    - <code>wake</code>
-    - <code>sleep</code>
-    - <code>occupied</code>
-    - <code>unoccupied</code>
-</details>
-<strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
+  <strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
+  <strong><code>display_name</code></strong> <i>String</i>
+  
+    Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>display_name</code></strong> <i>String</i>
+  <strong><code>ecobee_metadata</code></strong> <i>Object</i>
+  
+    Metadata specific to the Ecobee climate, if applicable.
 
-  Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
-<strong><code>ecobee_metadata</code></strong> <i>Object</i>
+  <strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
+  
+    Reference to the Ecobee climate, if applicable.
 
-  Metadata specific to the Ecobee climate, if applicable.
-<strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
+  <strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
+  
+    Indicates if the climate preset is optimized by Ecobee.
 
-  Reference to the Ecobee climate, if applicable.
-<strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
+  <strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
+  
+    Indicates whether the climate preset is owned by the user or the system.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>user</code>
+      - <code>system</code>
+  </details>
 
-  Indicates if the climate preset is optimized by Ecobee.
-<strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
+  <strong><code>fan_mode_setting</code></strong> <i>Enum</i>
+  
+    Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>auto</code>
+      - <code>on</code>
+      - <code>circulate</code>
+  </details>
 
-  Indicates whether the climate preset is owned by the user or the system.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-    - <code>user</code>
-    - <code>system</code>
-</details>
-<strong><code>fan_mode_setting</code></strong> <i>Enum</i>
+  <strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
+  
+    Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>off</code>
+      - <code>heat</code>
+      - <code>cool</code>
+      - <code>heat_cool</code>
+  </details>
 
-    - <code>auto</code>
-    - <code>on</code>
-    - <code>circulate</code>
-</details>
-<strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
+  <strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
+  
+    Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+  
+    {% hint style="warning" %}
+    **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
+    {% endhint %}
 
-  Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
+  <strong><code>name</code></strong> <i>String</i>
+  
+    User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
-
-  Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-<details>
-    <summary>Enum values:</summary>
-
-    - <code>off</code>
-    - <code>heat</code>
-    - <code>cool</code>
-    - <code>heat_cool</code>
-</details>
-<strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
-
-  Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
-
-  {% hint style="warning" %}
-  **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
-  {% endhint %}
-<strong><code>name</code></strong> <i>String</i>
-
-  User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 </details>
 
 ---
@@ -4012,34 +4033,40 @@ Configured [daily programs](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>created_at</code></strong> <i>Datetime</i>
+  <strong><code>created_at</code></strong> <i>Datetime</i>
+  
+    Date and time at which the thermostat daily program was created.
 
-  Date and time at which the thermostat daily program was created.
-<strong><code>device_id</code></strong> <i>UUID</i>
+  <strong><code>device_id</code></strong> <i>UUID</i>
+  
+    ID of the thermostat device on which the thermostat daily program is configured.
 
-  ID of the thermostat device on which the thermostat daily program is configured.
-<strong><code>name</code></strong> <i>String</i>
+  <strong><code>name</code></strong> <i>String</i>
+  
+    User-friendly name to identify the thermostat daily program.
 
-  User-friendly name to identify the thermostat daily program.
-<strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
+  <strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
+  
+    Array of thermostat daily program periods.
+  
+  - <strong><code>climate_preset_key</code></strong> <i>String</i>
+  
+    Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
+  
+  
+  - <strong><code>starts_at_time</code></strong> <i>String</i>
+  
+    Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+  
 
-  Array of thermostat daily program periods.
+  <strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
+  
+    ID of the thermostat daily program.
 
-- <strong><code>climate_preset_key</code></strong> <i>String</i>
+  <strong><code>workspace_id</code></strong> <i>UUID</i>
+  
+    ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 
-  Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
-
-
-- <strong><code>starts_at_time</code></strong> <i>String</i>
-
-  Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-
-<strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
-
-  ID of the thermostat daily program.
-<strong><code>workspace_id</code></strong> <i>UUID</i>
-
-  ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 </details>
 
 ---

--- a/docs/api/devices/README.md
+++ b/docs/api/devices/README.md
@@ -3063,31 +3063,31 @@ Constraints on access codes for the device. Seam represents each constraint as a
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>constraint_type</code></strong> <i>Enum</i>
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>no_zeros</code>
-      - <code>cannot_start_with_12</code>
-      - <code>no_triple_consecutive_ints</code>
-      - <code>cannot_specify_pin_code</code>
-      - <code>pin_code_matches_existing_set</code>
-      - <code>start_date_in_future</code>
-      - <code>no_ascending_or_descending_sequence</code>
-      - <code>at_least_three_unique_digits</code>
-      - <code>cannot_contain_089</code>
-      - <code>cannot_contain_0789</code>
-      - <code>name_length</code>
-      - <code>name_must_be_unique</code>
-  </details>
+<strong><code>constraint_type</code></strong> <i>Enum</i>
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>max_length</code></strong> <i>Number</i>
-  
-    Maximum name length constraint for access codes.
+    - <code>no_zeros</code>
+    - <code>cannot_start_with_12</code>
+    - <code>no_triple_consecutive_ints</code>
+    - <code>cannot_specify_pin_code</code>
+    - <code>pin_code_matches_existing_set</code>
+    - <code>start_date_in_future</code>
+    - <code>no_ascending_or_descending_sequence</code>
+    - <code>at_least_three_unique_digits</code>
+    - <code>cannot_contain_089</code>
+    - <code>cannot_contain_0789</code>
+    - <code>name_length</code>
+    - <code>name_must_be_unique</code>
+</details>
 
-  <strong><code>min_length</code></strong> <i>Number</i>
-  
-    Minimum name length constraint for access codes.
+<strong><code>max_length</code></strong> <i>Number</i>
+
+  Maximum name length constraint for access codes.
+
+<strong><code>min_length</code></strong> <i>Number</i>
+
+  Minimum name length constraint for access codes.
 
 </details>
 
@@ -3445,112 +3445,112 @@ Available [climate presets](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>can_delete</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
+<strong><code>can_delete</code></strong> <i>Boolean</i>
 
-  <strong><code>can_edit</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
 
-  <strong><code>can_program</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
+<strong><code>can_edit</code></strong> <i>Boolean</i>
 
-  <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
 
-  <strong><code>climate_preset_mode</code></strong> <i>Enum</i>
-  
-    The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>home</code>
-      - <code>away</code>
-      - <code>wake</code>
-      - <code>sleep</code>
-      - <code>occupied</code>
-      - <code>unoccupied</code>
-  </details>
+<strong><code>can_program</code></strong> <i>Boolean</i>
 
-  <strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
 
-  <strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>climate_preset_key</code></strong> <i>String</i>
 
-  <strong><code>display_name</code></strong> <i>String</i>
-  
-    Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  <strong><code>ecobee_metadata</code></strong> <i>Object</i>
-  
-    Metadata specific to the Ecobee climate, if applicable.
+<strong><code>climate_preset_mode</code></strong> <i>Enum</i>
 
-  <strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
-  
-    Reference to the Ecobee climate, if applicable.
+  The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
-  
-    Indicates if the climate preset is optimized by Ecobee.
+    - <code>home</code>
+    - <code>away</code>
+    - <code>wake</code>
+    - <code>sleep</code>
+    - <code>occupied</code>
+    - <code>unoccupied</code>
+</details>
 
-  <strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
-  
-    Indicates whether the climate preset is owned by the user or the system.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>user</code>
-      - <code>system</code>
-  </details>
+<strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
 
-  <strong><code>fan_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>auto</code>
-      - <code>on</code>
-      - <code>circulate</code>
-  </details>
+  Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  <strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
 
-  <strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  <strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>off</code>
-      - <code>heat</code>
-      - <code>cool</code>
-      - <code>heat_cool</code>
-  </details>
+<strong><code>display_name</code></strong> <i>String</i>
 
-  <strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
-  
-    Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
-  
-    {% hint style="warning" %}
-    **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
-    {% endhint %}
+  Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+<strong><code>ecobee_metadata</code></strong> <i>Object</i>
+
+  Metadata specific to the Ecobee climate, if applicable.
+
+<strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
+
+  Reference to the Ecobee climate, if applicable.
+
+<strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
+
+  Indicates if the climate preset is optimized by Ecobee.
+
+<strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
+
+  Indicates whether the climate preset is owned by the user or the system.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>user</code>
+    - <code>system</code>
+</details>
+
+<strong><code>fan_mode_setting</code></strong> <i>Enum</i>
+
+  Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>auto</code>
+    - <code>on</code>
+    - <code>circulate</code>
+</details>
+
+<strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
+
+  Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+
+<strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
+
+  Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+
+<strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
+
+  Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>off</code>
+    - <code>heat</code>
+    - <code>cool</code>
+    - <code>heat_cool</code>
+</details>
+
+<strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
+
+  Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+
+  {% hint style="warning" %}
+  **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
+  {% endhint %}
+
+<strong><code>name</code></strong> <i>String</i>
+
+  User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
 </details>
 
@@ -4033,39 +4033,39 @@ Configured [daily programs](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which the thermostat daily program was created.
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>device_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat device on which the thermostat daily program is configured.
+  Date and time at which the thermostat daily program was created.
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the thermostat daily program.
+<strong><code>device_id</code></strong> <i>UUID</i>
 
-  <strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
-  
-    Array of thermostat daily program periods.
-  
-  - <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
-  
-  
-  - <strong><code>starts_at_time</code></strong> <i>String</i>
-  
-    Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-  
+  ID of the thermostat device on which the thermostat daily program is configured.
 
-  <strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat daily program.
+<strong><code>name</code></strong> <i>String</i>
 
-  <strong><code>workspace_id</code></strong> <i>UUID</i>
-  
-    ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
+  User-friendly name to identify the thermostat daily program.
+
+<strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
+
+  Array of thermostat daily program periods.
+
+- <strong><code>climate_preset_key</code></strong> <i>String</i>
+
+  Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
+
+
+- <strong><code>starts_at_time</code></strong> <i>String</i>
+
+  Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
+
+<strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
+
+  ID of the thermostat daily program.
+
+<strong><code>workspace_id</code></strong> <i>UUID</i>
+
+  ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 
 </details>
 

--- a/docs/api/devices/README.md
+++ b/docs/api/devices/README.md
@@ -3063,32 +3063,29 @@ Constraints on access codes for the device. Seam represents each constraint as a
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>constraint_type</code></strong> <i>Enum</i>
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>constraint_type</code></strong> <i>Enum</i>
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>no_zeros</code>
-      - <code>cannot_start_with_12</code>
-      - <code>no_triple_consecutive_ints</code>
-      - <code>cannot_specify_pin_code</code>
-      - <code>pin_code_matches_existing_set</code>
-      - <code>start_date_in_future</code>
-      - <code>no_ascending_or_descending_sequence</code>
-      - <code>at_least_three_unique_digits</code>
-      - <code>cannot_contain_089</code>
-      - <code>cannot_contain_0789</code>
-      - <code>name_length</code>
-      - <code>name_must_be_unique</code>
-  </details>
+    - <code>no_zeros</code>
+    - <code>cannot_start_with_12</code>
+    - <code>no_triple_consecutive_ints</code>
+    - <code>cannot_specify_pin_code</code>
+    - <code>pin_code_matches_existing_set</code>
+    - <code>start_date_in_future</code>
+    - <code>no_ascending_or_descending_sequence</code>
+    - <code>at_least_three_unique_digits</code>
+    - <code>cannot_contain_089</code>
+    - <code>cannot_contain_0789</code>
+    - <code>name_length</code>
+    - <code>name_must_be_unique</code>
+</details>
+<strong><code>max_length</code></strong> <i>Number</i>
 
-  <strong><code>max_length</code></strong> <i>Number</i>
-  
-    Maximum name length constraint for access codes.
+  Maximum name length constraint for access codes.
+<strong><code>min_length</code></strong> <i>Number</i>
 
-  <strong><code>min_length</code></strong> <i>Number</i>
-  
-    Minimum name length constraint for access codes.
+  Minimum name length constraint for access codes.
 </details>
 
 ---
@@ -3445,113 +3442,95 @@ Available [climate presets](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>can_delete</code></strong> <i>Boolean</i>
 
-  <strong><code>can_delete</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
+<strong><code>can_edit</code></strong> <i>Boolean</i>
 
-  <strong><code>can_edit</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
+<strong><code>can_program</code></strong> <i>Boolean</i>
 
-  <strong><code>can_program</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
+<strong><code>climate_preset_key</code></strong> <i>String</i>
 
-  <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+<strong><code>climate_preset_mode</code></strong> <i>Enum</i>
 
-  <strong><code>climate_preset_mode</code></strong> <i>Enum</i>
-  
-    The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>home</code>
-      - <code>away</code>
-      - <code>wake</code>
-      - <code>sleep</code>
-      - <code>occupied</code>
-      - <code>unoccupied</code>
-  </details>
+  The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+    - <code>home</code>
+    - <code>away</code>
+    - <code>wake</code>
+    - <code>sleep</code>
+    - <code>occupied</code>
+    - <code>unoccupied</code>
+</details>
+<strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
 
-  <strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
 
-  <strong><code>display_name</code></strong> <i>String</i>
-  
-    Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>display_name</code></strong> <i>String</i>
 
-  <strong><code>ecobee_metadata</code></strong> <i>Object</i>
-  
-    Metadata specific to the Ecobee climate, if applicable.
+  Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+<strong><code>ecobee_metadata</code></strong> <i>Object</i>
 
-  <strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
-  
-    Reference to the Ecobee climate, if applicable.
+  Metadata specific to the Ecobee climate, if applicable.
+<strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
 
-  <strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
-  
-    Indicates if the climate preset is optimized by Ecobee.
+  Reference to the Ecobee climate, if applicable.
+<strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
 
-  <strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
-  
-    Indicates whether the climate preset is owned by the user or the system.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>user</code>
-      - <code>system</code>
-  </details>
+  Indicates if the climate preset is optimized by Ecobee.
+<strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
 
-  <strong><code>fan_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>auto</code>
-      - <code>on</code>
-      - <code>circulate</code>
-  </details>
+  Indicates whether the climate preset is owned by the user or the system.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+    - <code>user</code>
+    - <code>system</code>
+</details>
+<strong><code>fan_mode_setting</code></strong> <i>Enum</i>
 
-  <strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>off</code>
-      - <code>heat</code>
-      - <code>cool</code>
-      - <code>heat_cool</code>
-  </details>
+    - <code>auto</code>
+    - <code>on</code>
+    - <code>circulate</code>
+</details>
+<strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
 
-  <strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
-  
-    Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
-  
-    {% hint style="warning" %}
-    **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
-    {% endhint %}
+  Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
+
+  Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>off</code>
+    - <code>heat</code>
+    - <code>cool</code>
+    - <code>heat_cool</code>
+</details>
+<strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
+
+  Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+
+  {% hint style="warning" %}
+  **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
+  {% endhint %}
+<strong><code>name</code></strong> <i>String</i>
+
+  User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 </details>
 
 ---
@@ -4033,40 +4012,34 @@ Configured [daily programs](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which the thermostat daily program was created.
+  Date and time at which the thermostat daily program was created.
+<strong><code>device_id</code></strong> <i>UUID</i>
 
-  <strong><code>device_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat device on which the thermostat daily program is configured.
+  ID of the thermostat device on which the thermostat daily program is configured.
+<strong><code>name</code></strong> <i>String</i>
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the thermostat daily program.
+  User-friendly name to identify the thermostat daily program.
+<strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
 
-  <strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
-  
-    Array of thermostat daily program periods.
-  
-  - <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
-  
-  
-  - <strong><code>starts_at_time</code></strong> <i>String</i>
-  
-    Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-  
+  Array of thermostat daily program periods.
 
-  <strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat daily program.
+- <strong><code>climate_preset_key</code></strong> <i>String</i>
 
-  <strong><code>workspace_id</code></strong> <i>UUID</i>
-  
-    ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
+  Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
+
+
+- <strong><code>starts_at_time</code></strong> <i>String</i>
+
+  Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
+<strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
+
+  ID of the thermostat daily program.
+<strong><code>workspace_id</code></strong> <i>UUID</i>
+
+  ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 </details>
 
 ---

--- a/docs/api/locks/README.md
+++ b/docs/api/locks/README.md
@@ -1778,32 +1778,29 @@ Constraints on access codes for the device. Seam represents each constraint as a
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>constraint_type</code></strong> <i>Enum</i>
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>constraint_type</code></strong> <i>Enum</i>
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>no_zeros</code>
-      - <code>cannot_start_with_12</code>
-      - <code>no_triple_consecutive_ints</code>
-      - <code>cannot_specify_pin_code</code>
-      - <code>pin_code_matches_existing_set</code>
-      - <code>start_date_in_future</code>
-      - <code>no_ascending_or_descending_sequence</code>
-      - <code>at_least_three_unique_digits</code>
-      - <code>cannot_contain_089</code>
-      - <code>cannot_contain_0789</code>
-      - <code>name_length</code>
-      - <code>name_must_be_unique</code>
-  </details>
+    - <code>no_zeros</code>
+    - <code>cannot_start_with_12</code>
+    - <code>no_triple_consecutive_ints</code>
+    - <code>cannot_specify_pin_code</code>
+    - <code>pin_code_matches_existing_set</code>
+    - <code>start_date_in_future</code>
+    - <code>no_ascending_or_descending_sequence</code>
+    - <code>at_least_three_unique_digits</code>
+    - <code>cannot_contain_089</code>
+    - <code>cannot_contain_0789</code>
+    - <code>name_length</code>
+    - <code>name_must_be_unique</code>
+</details>
+<strong><code>max_length</code></strong> <i>Number</i>
 
-  <strong><code>max_length</code></strong> <i>Number</i>
-  
-    Maximum name length constraint for access codes.
+  Maximum name length constraint for access codes.
+<strong><code>min_length</code></strong> <i>Number</i>
 
-  <strong><code>min_length</code></strong> <i>Number</i>
-  
-    Minimum name length constraint for access codes.
+  Minimum name length constraint for access codes.
 </details>
 
 ---

--- a/docs/api/locks/README.md
+++ b/docs/api/locks/README.md
@@ -1778,31 +1778,31 @@ Constraints on access codes for the device. Seam represents each constraint as a
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>constraint_type</code></strong> <i>Enum</i>
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>no_zeros</code>
-      - <code>cannot_start_with_12</code>
-      - <code>no_triple_consecutive_ints</code>
-      - <code>cannot_specify_pin_code</code>
-      - <code>pin_code_matches_existing_set</code>
-      - <code>start_date_in_future</code>
-      - <code>no_ascending_or_descending_sequence</code>
-      - <code>at_least_three_unique_digits</code>
-      - <code>cannot_contain_089</code>
-      - <code>cannot_contain_0789</code>
-      - <code>name_length</code>
-      - <code>name_must_be_unique</code>
-  </details>
+<strong><code>constraint_type</code></strong> <i>Enum</i>
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>max_length</code></strong> <i>Number</i>
-  
-    Maximum name length constraint for access codes.
+    - <code>no_zeros</code>
+    - <code>cannot_start_with_12</code>
+    - <code>no_triple_consecutive_ints</code>
+    - <code>cannot_specify_pin_code</code>
+    - <code>pin_code_matches_existing_set</code>
+    - <code>start_date_in_future</code>
+    - <code>no_ascending_or_descending_sequence</code>
+    - <code>at_least_three_unique_digits</code>
+    - <code>cannot_contain_089</code>
+    - <code>cannot_contain_0789</code>
+    - <code>name_length</code>
+    - <code>name_must_be_unique</code>
+</details>
 
-  <strong><code>min_length</code></strong> <i>Number</i>
-  
-    Minimum name length constraint for access codes.
+<strong><code>max_length</code></strong> <i>Number</i>
+
+  Maximum name length constraint for access codes.
+
+<strong><code>min_length</code></strong> <i>Number</i>
+
+  Minimum name length constraint for access codes.
 
 </details>
 

--- a/docs/api/locks/README.md
+++ b/docs/api/locks/README.md
@@ -1778,29 +1778,32 @@ Constraints on access codes for the device. Seam represents each constraint as a
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>constraint_type</code></strong> <i>Enum</i>
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>constraint_type</code></strong> <i>Enum</i>
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>no_zeros</code>
+      - <code>cannot_start_with_12</code>
+      - <code>no_triple_consecutive_ints</code>
+      - <code>cannot_specify_pin_code</code>
+      - <code>pin_code_matches_existing_set</code>
+      - <code>start_date_in_future</code>
+      - <code>no_ascending_or_descending_sequence</code>
+      - <code>at_least_three_unique_digits</code>
+      - <code>cannot_contain_089</code>
+      - <code>cannot_contain_0789</code>
+      - <code>name_length</code>
+      - <code>name_must_be_unique</code>
+  </details>
 
-    - <code>no_zeros</code>
-    - <code>cannot_start_with_12</code>
-    - <code>no_triple_consecutive_ints</code>
-    - <code>cannot_specify_pin_code</code>
-    - <code>pin_code_matches_existing_set</code>
-    - <code>start_date_in_future</code>
-    - <code>no_ascending_or_descending_sequence</code>
-    - <code>at_least_three_unique_digits</code>
-    - <code>cannot_contain_089</code>
-    - <code>cannot_contain_0789</code>
-    - <code>name_length</code>
-    - <code>name_must_be_unique</code>
-</details>
-<strong><code>max_length</code></strong> <i>Number</i>
+  <strong><code>max_length</code></strong> <i>Number</i>
+  
+    Maximum name length constraint for access codes.
 
-  Maximum name length constraint for access codes.
-<strong><code>min_length</code></strong> <i>Number</i>
+  <strong><code>min_length</code></strong> <i>Number</i>
+  
+    Minimum name length constraint for access codes.
 
-  Minimum name length constraint for access codes.
 </details>
 
 ---

--- a/docs/api/phones/README.md
+++ b/docs/api/phones/README.md
@@ -104,9 +104,9 @@ Errors associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>error_code</code></strong> <i>String</i>
+<strong><code>error_code</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
+<strong><code>message</code></strong> <i>String</i>
 
 </details>
 
@@ -129,9 +129,9 @@ Warnings associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>message</code></strong> <i>String</i>
+<strong><code>message</code></strong> <i>String</i>
 
-  <strong><code>warning_code</code></strong> <i>String</i>
+<strong><code>warning_code</code></strong> <i>String</i>
 
 </details>
 

--- a/docs/api/phones/README.md
+++ b/docs/api/phones/README.md
@@ -104,8 +104,10 @@ Errors associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>error_code</code></strong> <i>String</i>
-<strong><code>message</code></strong> <i>String</i>
+  <strong><code>error_code</code></strong> <i>String</i>
+
+  <strong><code>message</code></strong> <i>String</i>
+
 </details>
 
 ---
@@ -127,8 +129,10 @@ Warnings associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>message</code></strong> <i>String</i>
-<strong><code>warning_code</code></strong> <i>String</i>
+  <strong><code>message</code></strong> <i>String</i>
+
+  <strong><code>warning_code</code></strong> <i>String</i>
+
 </details>
 
 ---

--- a/docs/api/phones/README.md
+++ b/docs/api/phones/README.md
@@ -104,10 +104,8 @@ Errors associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
-
-  <strong><code>error_code</code></strong> <i>String</i>
-
-  <strong><code>message</code></strong> <i>String</i>
+<strong><code>error_code</code></strong> <i>String</i>
+<strong><code>message</code></strong> <i>String</i>
 </details>
 
 ---
@@ -129,10 +127,8 @@ Warnings associated with the phone.
 
 <details>
   <summary>Child Object Properties</summary>
-
-  <strong><code>message</code></strong> <i>String</i>
-
-  <strong><code>warning_code</code></strong> <i>String</i>
+<strong><code>message</code></strong> <i>String</i>
+<strong><code>warning_code</code></strong> <i>String</i>
 </details>
 
 ---

--- a/docs/api/thermostats/README.md
+++ b/docs/api/thermostats/README.md
@@ -1924,112 +1924,112 @@ Available [climate presets](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>can_delete</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
+<strong><code>can_delete</code></strong> <i>Boolean</i>
 
-  <strong><code>can_edit</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
 
-  <strong><code>can_program</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
+<strong><code>can_edit</code></strong> <i>Boolean</i>
 
-  <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
 
-  <strong><code>climate_preset_mode</code></strong> <i>Enum</i>
-  
-    The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>home</code>
-      - <code>away</code>
-      - <code>wake</code>
-      - <code>sleep</code>
-      - <code>occupied</code>
-      - <code>unoccupied</code>
-  </details>
+<strong><code>can_program</code></strong> <i>Boolean</i>
 
-  <strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
 
-  <strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>climate_preset_key</code></strong> <i>String</i>
 
-  <strong><code>display_name</code></strong> <i>String</i>
-  
-    Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  <strong><code>ecobee_metadata</code></strong> <i>Object</i>
-  
-    Metadata specific to the Ecobee climate, if applicable.
+<strong><code>climate_preset_mode</code></strong> <i>Enum</i>
 
-  <strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
-  
-    Reference to the Ecobee climate, if applicable.
+  The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
-  
-    Indicates if the climate preset is optimized by Ecobee.
+    - <code>home</code>
+    - <code>away</code>
+    - <code>wake</code>
+    - <code>sleep</code>
+    - <code>occupied</code>
+    - <code>unoccupied</code>
+</details>
 
-  <strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
-  
-    Indicates whether the climate preset is owned by the user or the system.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>user</code>
-      - <code>system</code>
-  </details>
+<strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
 
-  <strong><code>fan_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>auto</code>
-      - <code>on</code>
-      - <code>circulate</code>
-  </details>
+  Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  <strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
 
-  <strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  <strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>off</code>
-      - <code>heat</code>
-      - <code>cool</code>
-      - <code>heat_cool</code>
-  </details>
+<strong><code>display_name</code></strong> <i>String</i>
 
-  <strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
-  
-    Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
-  
-    {% hint style="warning" %}
-    **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
-    {% endhint %}
+  Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+<strong><code>ecobee_metadata</code></strong> <i>Object</i>
+
+  Metadata specific to the Ecobee climate, if applicable.
+
+<strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
+
+  Reference to the Ecobee climate, if applicable.
+
+<strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
+
+  Indicates if the climate preset is optimized by Ecobee.
+
+<strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
+
+  Indicates whether the climate preset is owned by the user or the system.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>user</code>
+    - <code>system</code>
+</details>
+
+<strong><code>fan_mode_setting</code></strong> <i>Enum</i>
+
+  Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>auto</code>
+    - <code>on</code>
+    - <code>circulate</code>
+</details>
+
+<strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
+
+  Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+
+<strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
+
+  Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+
+<strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
+
+  Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>off</code>
+    - <code>heat</code>
+    - <code>cool</code>
+    - <code>heat_cool</code>
+</details>
+
+<strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
+
+  Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+
+  {% hint style="warning" %}
+  **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
+  {% endhint %}
+
+<strong><code>name</code></strong> <i>String</i>
+
+  User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
 </details>
 
@@ -3439,39 +3439,39 @@ Configured [daily programs](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which the thermostat daily program was created.
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>device_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat device on which the thermostat daily program is configured.
+  Date and time at which the thermostat daily program was created.
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the thermostat daily program.
+<strong><code>device_id</code></strong> <i>UUID</i>
 
-  <strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
-  
-    Array of thermostat daily program periods.
-  
-  - <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
-  
-  
-  - <strong><code>starts_at_time</code></strong> <i>String</i>
-  
-    Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-  
+  ID of the thermostat device on which the thermostat daily program is configured.
 
-  <strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat daily program.
+<strong><code>name</code></strong> <i>String</i>
 
-  <strong><code>workspace_id</code></strong> <i>UUID</i>
-  
-    ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
+  User-friendly name to identify the thermostat daily program.
+
+<strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
+
+  Array of thermostat daily program periods.
+
+- <strong><code>climate_preset_key</code></strong> <i>String</i>
+
+  Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
+
+
+- <strong><code>starts_at_time</code></strong> <i>String</i>
+
+  Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
+
+<strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
+
+  ID of the thermostat daily program.
+
+<strong><code>workspace_id</code></strong> <i>UUID</i>
+
+  ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 
 </details>
 

--- a/docs/api/thermostats/README.md
+++ b/docs/api/thermostats/README.md
@@ -1924,95 +1924,113 @@ Available [climate presets](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>can_delete</code></strong> <i>Boolean</i>
+  <strong><code>can_delete</code></strong> <i>Boolean</i>
+  
+    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
 
-  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
-<strong><code>can_edit</code></strong> <i>Boolean</i>
+  <strong><code>can_edit</code></strong> <i>Boolean</i>
+  
+    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
 
-  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
-<strong><code>can_program</code></strong> <i>Boolean</i>
+  <strong><code>can_program</code></strong> <i>Boolean</i>
+  
+    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
 
-  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
-<strong><code>climate_preset_key</code></strong> <i>String</i>
+  <strong><code>climate_preset_key</code></strong> <i>String</i>
+  
+    Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
-<strong><code>climate_preset_mode</code></strong> <i>Enum</i>
+  <strong><code>climate_preset_mode</code></strong> <i>Enum</i>
+  
+    The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>home</code>
+      - <code>away</code>
+      - <code>wake</code>
+      - <code>sleep</code>
+      - <code>occupied</code>
+      - <code>unoccupied</code>
+  </details>
 
-  The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-    - <code>home</code>
-    - <code>away</code>
-    - <code>wake</code>
-    - <code>sleep</code>
-    - <code>occupied</code>
-    - <code>unoccupied</code>
-</details>
-<strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
+  <strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
+  <strong><code>display_name</code></strong> <i>String</i>
+  
+    Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>display_name</code></strong> <i>String</i>
+  <strong><code>ecobee_metadata</code></strong> <i>Object</i>
+  
+    Metadata specific to the Ecobee climate, if applicable.
 
-  Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
-<strong><code>ecobee_metadata</code></strong> <i>Object</i>
+  <strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
+  
+    Reference to the Ecobee climate, if applicable.
 
-  Metadata specific to the Ecobee climate, if applicable.
-<strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
+  <strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
+  
+    Indicates if the climate preset is optimized by Ecobee.
 
-  Reference to the Ecobee climate, if applicable.
-<strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
+  <strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
+  
+    Indicates whether the climate preset is owned by the user or the system.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>user</code>
+      - <code>system</code>
+  </details>
 
-  Indicates if the climate preset is optimized by Ecobee.
-<strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
+  <strong><code>fan_mode_setting</code></strong> <i>Enum</i>
+  
+    Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>auto</code>
+      - <code>on</code>
+      - <code>circulate</code>
+  </details>
 
-  Indicates whether the climate preset is owned by the user or the system.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-    - <code>user</code>
-    - <code>system</code>
-</details>
-<strong><code>fan_mode_setting</code></strong> <i>Enum</i>
+  <strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
+  
+    Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
 
-  Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-<details>
-    <summary>Enum values:</summary>
+  <strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
+  
+    Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+  <details>
+      <summary>Enum values:</summary>
+  
+      - <code>off</code>
+      - <code>heat</code>
+      - <code>cool</code>
+      - <code>heat_cool</code>
+  </details>
 
-    - <code>auto</code>
-    - <code>on</code>
-    - <code>circulate</code>
-</details>
-<strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
+  <strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
+  
+    Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+  
+    {% hint style="warning" %}
+    **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
+    {% endhint %}
 
-  Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
+  <strong><code>name</code></strong> <i>String</i>
+  
+    User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 
-  Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
-<strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
-
-  Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-<details>
-    <summary>Enum values:</summary>
-
-    - <code>off</code>
-    - <code>heat</code>
-    - <code>cool</code>
-    - <code>heat_cool</code>
-</details>
-<strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
-
-  Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
-
-  {% hint style="warning" %}
-  **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
-  {% endhint %}
-<strong><code>name</code></strong> <i>String</i>
-
-  User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 </details>
 
 ---
@@ -3421,34 +3439,40 @@ Configured [daily programs](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>created_at</code></strong> <i>Datetime</i>
+  <strong><code>created_at</code></strong> <i>Datetime</i>
+  
+    Date and time at which the thermostat daily program was created.
 
-  Date and time at which the thermostat daily program was created.
-<strong><code>device_id</code></strong> <i>UUID</i>
+  <strong><code>device_id</code></strong> <i>UUID</i>
+  
+    ID of the thermostat device on which the thermostat daily program is configured.
 
-  ID of the thermostat device on which the thermostat daily program is configured.
-<strong><code>name</code></strong> <i>String</i>
+  <strong><code>name</code></strong> <i>String</i>
+  
+    User-friendly name to identify the thermostat daily program.
 
-  User-friendly name to identify the thermostat daily program.
-<strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
+  <strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
+  
+    Array of thermostat daily program periods.
+  
+  - <strong><code>climate_preset_key</code></strong> <i>String</i>
+  
+    Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
+  
+  
+  - <strong><code>starts_at_time</code></strong> <i>String</i>
+  
+    Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+  
 
-  Array of thermostat daily program periods.
+  <strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
+  
+    ID of the thermostat daily program.
 
-- <strong><code>climate_preset_key</code></strong> <i>String</i>
+  <strong><code>workspace_id</code></strong> <i>UUID</i>
+  
+    ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 
-  Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
-
-
-- <strong><code>starts_at_time</code></strong> <i>String</i>
-
-  Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-
-<strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
-
-  ID of the thermostat daily program.
-<strong><code>workspace_id</code></strong> <i>UUID</i>
-
-  ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 </details>
 
 ---

--- a/docs/api/thermostats/README.md
+++ b/docs/api/thermostats/README.md
@@ -1924,113 +1924,95 @@ Available [climate presets](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>can_delete</code></strong> <i>Boolean</i>
 
-  <strong><code>can_delete</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be deleted.
+<strong><code>can_edit</code></strong> <i>Boolean</i>
 
-  <strong><code>can_edit</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be edited.
+<strong><code>can_program</code></strong> <i>Boolean</i>
 
-  <strong><code>can_program</code></strong> <i>Boolean</i>
-  
-    Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
+  Indicates whether the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) key can be programmed in a thermostat daily program.
+<strong><code>climate_preset_key</code></strong> <i>String</i>
 
-  <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Unique key to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+<strong><code>climate_preset_mode</code></strong> <i>Enum</i>
 
-  <strong><code>climate_preset_mode</code></strong> <i>Enum</i>
-  
-    The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>home</code>
-      - <code>away</code>
-      - <code>wake</code>
-      - <code>sleep</code>
-      - <code>occupied</code>
-      - <code>unoccupied</code>
-  </details>
+  The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+    - <code>home</code>
+    - <code>away</code>
+    - <code>wake</code>
+    - <code>sleep</code>
+    - <code>occupied</code>
+    - <code>unoccupied</code>
+</details>
+<strong><code>cooling_set_point_celsius</code></strong> <i>Number</i>
 
-  <strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Temperature to which the thermostat should cool (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>cooling_set_point_fahrenheit</code></strong> <i>Number</i>
 
-  <strong><code>display_name</code></strong> <i>String</i>
-  
-    Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Temperature to which the thermostat should cool (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>display_name</code></strong> <i>String</i>
 
-  <strong><code>ecobee_metadata</code></strong> <i>Object</i>
-  
-    Metadata specific to the Ecobee climate, if applicable.
+  Display name for the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+<strong><code>ecobee_metadata</code></strong> <i>Object</i>
 
-  <strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
-  
-    Reference to the Ecobee climate, if applicable.
+  Metadata specific to the Ecobee climate, if applicable.
+<strong><code>ecobee_metadata.climate_ref</code></strong> <i>String</i>
 
-  <strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
-  
-    Indicates if the climate preset is optimized by Ecobee.
+  Reference to the Ecobee climate, if applicable.
+<strong><code>ecobee_metadata.is_optimized</code></strong> <i>Boolean</i>
 
-  <strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
-  
-    Indicates whether the climate preset is owned by the user or the system.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>user</code>
-      - <code>system</code>
-  </details>
+  Indicates if the climate preset is optimized by Ecobee.
+<strong><code>ecobee_metadata.owner</code></strong> <i>Enum</i>
 
-  <strong><code>fan_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>auto</code>
-      - <code>on</code>
-      - <code>circulate</code>
-  </details>
+  Indicates whether the climate preset is owned by the user or the system.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+    - <code>user</code>
+    - <code>system</code>
+</details>
+<strong><code>fan_mode_setting</code></strong> <i>Enum</i>
 
-  <strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
-  
-    Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+  Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+<details>
+    <summary>Enum values:</summary>
 
-  <strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
-  
-    Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
-  <details>
-      <summary>Enum values:</summary>
-  
-      - <code>off</code>
-      - <code>heat</code>
-      - <code>cool</code>
-      - <code>heat_cool</code>
-  </details>
+    - <code>auto</code>
+    - <code>on</code>
+    - <code>circulate</code>
+</details>
+<strong><code>heating_set_point_celsius</code></strong> <i>Number</i>
 
-  <strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
-  
-    Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
-  
-    {% hint style="warning" %}
-    **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
-    {% endhint %}
+  Temperature to which the thermostat should heat (in °C). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>heating_set_point_fahrenheit</code></strong> <i>Number</i>
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
+  Temperature to which the thermostat should heat (in °F). See also [Set Points](../../capability-guides/thermostats/understanding-thermostat-concepts/set-points.md).
+<strong><code>hvac_mode_setting</code></strong> <i>Enum</i>
+
+  Desired [HVAC mode](../../capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode.md) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+<details>
+    <summary>Enum values:</summary>
+
+    - <code>off</code>
+    - <code>heat</code>
+    - <code>cool</code>
+    - <code>heat_cool</code>
+</details>
+<strong><code>manual_override_allowed</code></strong> <i>Boolean</i>
+
+  Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md#specifying-manual-override-permissions).
+
+  {% hint style="warning" %}
+  **Deprecated**. Use 'thermostat_schedule.is_override_allowed'
+  {% endhint %}
+<strong><code>name</code></strong> <i>String</i>
+
+  User-friendly name to identify the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md).
 </details>
 
 ---
@@ -3439,40 +3421,34 @@ Configured [daily programs](../../capability-guides/thermostats/creating-and-man
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>created_at</code></strong> <i>Datetime</i>
 
-  <strong><code>created_at</code></strong> <i>Datetime</i>
-  
-    Date and time at which the thermostat daily program was created.
+  Date and time at which the thermostat daily program was created.
+<strong><code>device_id</code></strong> <i>UUID</i>
 
-  <strong><code>device_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat device on which the thermostat daily program is configured.
+  ID of the thermostat device on which the thermostat daily program is configured.
+<strong><code>name</code></strong> <i>String</i>
 
-  <strong><code>name</code></strong> <i>String</i>
-  
-    User-friendly name to identify the thermostat daily program.
+  User-friendly name to identify the thermostat daily program.
+<strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
 
-  <strong><code>periods</code></strong> <i>List</i> <i>of Objects</i>
-  
-    Array of thermostat daily program periods.
-  
-  - <strong><code>climate_preset_key</code></strong> <i>String</i>
-  
-    Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
-  
-  
-  - <strong><code>starts_at_time</code></strong> <i>String</i>
-  
-    Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-  
+  Array of thermostat daily program periods.
 
-  <strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
-  
-    ID of the thermostat daily program.
+- <strong><code>climate_preset_key</code></strong> <i>String</i>
 
-  <strong><code>workspace_id</code></strong> <i>UUID</i>
-  
-    ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
+  Key of the [climate preset](../../capability-guides/thermostats/creating-and-managing-climate-presets/README.md) to activate at the `starts_at_time`.
+
+
+- <strong><code>starts_at_time</code></strong> <i>String</i>
+
+  Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+
+<strong><code>thermostat_daily_program_id</code></strong> <i>UUID</i>
+
+  ID of the thermostat daily program.
+<strong><code>workspace_id</code></strong> <i>UUID</i>
+
+  ID of the [workspace](../../core-concepts/workspaces/README.md) that contains the thermostat daily program.
 </details>
 
 ---

--- a/docs/api/thermostats/schedules/README.md
+++ b/docs/api/thermostats/schedules/README.md
@@ -78,14 +78,12 @@ Errors associated with the [thermostat schedule](../../../capability-guides/ther
 
 <details>
   <summary>Child Object Properties</summary>
+<strong><code>error_code</code></strong> <i>String</i>
 
-  <strong><code>error_code</code></strong> <i>String</i>
-  
-    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+<strong><code>message</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 </details>
 
 ---

--- a/docs/api/thermostats/schedules/README.md
+++ b/docs/api/thermostats/schedules/README.md
@@ -78,13 +78,13 @@ Errors associated with the [thermostat schedule](../../../capability-guides/ther
 
 <details>
   <summary>Child Object Properties</summary>
-  <strong><code>error_code</code></strong> <i>String</i>
-  
-    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+<strong><code>error_code</code></strong> <i>String</i>
 
-  <strong><code>message</code></strong> <i>String</i>
-  
-    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+
+<strong><code>message</code></strong> <i>String</i>
+
+  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 
 </details>
 

--- a/docs/api/thermostats/schedules/README.md
+++ b/docs/api/thermostats/schedules/README.md
@@ -78,12 +78,14 @@ Errors associated with the [thermostat schedule](../../../capability-guides/ther
 
 <details>
   <summary>Child Object Properties</summary>
-<strong><code>error_code</code></strong> <i>String</i>
+  <strong><code>error_code</code></strong> <i>String</i>
+  
+    Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
 
-  Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
-<strong><code>message</code></strong> <i>String</i>
+  <strong><code>message</code></strong> <i>String</i>
+  
+    Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 
-  Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
 </details>
 
 ---

--- a/src/layouts/partials/api-resource-property.hbs
+++ b/src/layouts/partials/api-resource-property.hbs
@@ -64,7 +64,8 @@ This variant has no additional specific properties.
 <details>
   <summary>Child Object Properties</summary>
   {{#each listProperties}}
-{{> property-nested this}}
+  {{> property-nested this}}
+
   {{/each}}
 </details>
 {{/if}}

--- a/src/layouts/partials/api-resource-property.hbs
+++ b/src/layouts/partials/api-resource-property.hbs
@@ -64,8 +64,7 @@ This variant has no additional specific properties.
 <details>
   <summary>Child Object Properties</summary>
   {{#each listProperties}}
-
-  {{> property-nested this}}
+{{> property-nested this}}
   {{/each}}
 </details>
 {{/if}}

--- a/src/layouts/partials/api-resource-property.hbs
+++ b/src/layouts/partials/api-resource-property.hbs
@@ -64,7 +64,7 @@ This variant has no additional specific properties.
 <details>
   <summary>Child Object Properties</summary>
   {{#each listProperties}}
-  {{> property-nested this}}
+{{> property-nested this}}
 
   {{/each}}
 </details>


### PR DESCRIPTION
Closes https://linear.app/seam/issue/CX-422/fix-rendering-for-descriptions-in-child-props

Was due to indenting

### Before

https://docs.seam.co/latest/api/thermostats#device.properties

<img width="1556" height="1370" alt="CleanShot 2025-07-11 at 12 27 09@2x" src="https://github.com/user-attachments/assets/cbfcbb5e-61fe-436a-a2ab-008e824da7f6" />

### After

https://docs.seam.co/latest/~/revisions/wZDB5ZhUE6KdyLPxLojS/api/thermostats#properties


<img width="1616" height="896" alt="CleanShot 2025-07-11 at 14 56 59@2x" src="https://github.com/user-attachments/assets/45b4c6ca-e84b-4cbe-b18b-4757d7bcdc85" />

