### PR TITLE
fix: hide _experimental properties

### DIFF
--- a/codegen/lib/layout/api-route.ts
+++ b/codegen/lib/layout/api-route.ts
@@ -423,6 +423,7 @@ export const groupProperties = (
   if (include != null) {
     const properties = groups
       .flatMap((g) => g.properties)
+      .filter((p) => !p.name.startsWith('_'))
       .sort((a, b) => a.name.localeCompare(b.name))
     return [
       {

--- a/docs/api/locks/README.md
+++ b/docs/api/locks/README.md
@@ -1562,14 +1562,6 @@ Unique identifier for the Seam workspace associated with the device.
 
 ## device.properties
 
-**`_experimental_supported_code_from_access_codes_lengths`** *List* *of Numbers*
-
-
-
-
-
----
-
 **`akiles_metadata`** *Object*
 
 Metadata for an Akiles device.

--- a/docs/api/thermostats/README.md
+++ b/docs/api/thermostats/README.md
@@ -1678,14 +1678,6 @@ Unique identifier for the Seam workspace associated with the device.
 
 ## device.properties
 
-**`_experimental_supported_code_from_access_codes_lengths`** *List* *of Numbers*
-
-
-
-
-
----
-
 **`active_thermostat_schedule`** *Object*
 
 Active [thermostat schedule](../../capability-guides/thermostats/creating-and-managing-thermostat-schedules.md).


### PR DESCRIPTION
Closes https://linear.app/seam/issue/CX-425/undocumented-property-included-in-generated-api-reference

Example property: `_experimental_supported_code_from_access_codes_lengths`

https://docs.seam.co/latest/api/thermostats

<img width="2240" height="1432" alt="CleanShot 2025-07-26 at 06 53 33@2x" src="https://github.com/user-attachments/assets/531d3327-56e9-4026-90f1-e53ea6d4e14d" />

Checked the property object but there doesn't seem to be anything indicating an experimental property:

```ts
{
  "name": "_experimental_supported_code_from_access_codes_lengths",
  "description": "",
  "isDeprecated": false,
  "deprecationMessage": "",
  "format": "List",
  "listItemFormat": "Number"
}
```

This PR relies on the convention to ignore all properties that start with `_` instead.