### PR TITLE
fix: legacy properties including undocumented properties

### DIFF
--- a/codegen/lib/layout/api-route.ts
+++ b/codegen/lib/layout/api-route.ts
@@ -190,7 +190,9 @@ export const setApiRouteLayoutContext = (
     const legacyPropertyGroups =
       legacyProperty != null && legacyProperty.format === 'object'
         ? groupProperties(
-            legacyProperty.properties,
+            legacyProperty.properties.filter(
+              ({ isUndocumented }) => !isUndocumented,
+            ),
             legacyProperty.propertyGroups,
             {
               include: metadata.include_groups,


### PR DESCRIPTION
Closes https://linear.app/seam/issue/CX-425/undocumented-property-included-in-generated-api-reference

Re-work of https://github.com/seamapi/docs/pull/759

Example property: `_experimental_supported_code_from_access_codes_lengths`

https://docs.seam.co/latest/api/thermostats

<img width="2240" height="1432" alt="CleanShot 2025-07-26 at 06 53 33@2x" src="https://github.com/user-attachments/assets/531d3327-56e9-4026-90f1-e53ea6d4e14d" />